### PR TITLE
Implement Schema layer with field metadata

### DIFF
--- a/src/cquill/schema.gleam
+++ b/src/cquill/schema.gleam
@@ -1,0 +1,476 @@
+// cquill Schema Layer
+//
+// This module defines the Schema type — pure metadata describing database tables.
+// It is the foundation of cquill's type-safe query building.
+//
+// ARCHITECTURAL PRINCIPLE: This layer is PURE — no I/O, no side effects.
+// It defines structure and metadata only.
+//
+// DESIGN PATTERN: Multiple schemas per domain
+// Following Ecto's pattern, you can define different schemas for:
+// - Full schema (all fields for reads)
+// - Insert schema (no auto-generated fields)
+// - Public schema (excluding sensitive fields)
+//
+// Example:
+// ```gleam
+// // Full schema for reads
+// let user_schema = schema.new("users")
+//   |> schema.field(field.integer("id") |> field.primary_key)
+//   |> schema.field(field.string("email") |> field.not_null)
+//   |> schema.field(field.string("password_hash") |> field.not_null)
+//   |> schema.field(field.datetime("inserted_at"))
+//
+// // Insert schema (no id, no timestamps)
+// let new_user_schema = schema.new("users")
+//   |> schema.field(field.string("email") |> field.not_null)
+//   |> schema.field(field.string("password_hash") |> field.not_null)
+// ```
+
+import cquill/schema/field.{type Constraint, type Field, type FieldType}
+import gleam/list
+import gleam/option.{type Option, None, Some}
+import gleam/string
+
+// ============================================================================
+// SCHEMA TYPE
+// ============================================================================
+
+/// A schema describes the structure of a database table.
+/// It contains metadata about fields, primary keys, and table-level constraints.
+pub type Schema {
+  Schema(
+    /// The source table name in the database
+    source: String,
+    /// Schema/namespace (e.g., "public" in Postgres)
+    table_schema: Option(String),
+    /// Ordered list of fields
+    fields: List(Field),
+    /// Primary key column names (supports composite keys)
+    primary_key: List(String),
+    /// Table-level constraints (multi-column unique, etc.)
+    table_constraints: List(TableConstraint),
+    /// Table comment/documentation
+    comment: Option(String),
+  )
+}
+
+/// Table-level constraints (apply to multiple columns)
+pub type TableConstraint {
+  /// Multi-column unique constraint
+  UniqueConstraint(name: String, columns: List(String))
+
+  /// Multi-column index (not enforced, but for documentation)
+  Index(name: String, columns: List(String), unique: Bool)
+
+  /// Table-level check constraint
+  TableCheck(name: String, expression: String)
+
+  /// Composite foreign key
+  CompositeForeignKey(
+    name: String,
+    columns: List(String),
+    references_table: String,
+    references_columns: List(String),
+  )
+}
+
+// ============================================================================
+// SCHEMA CONSTRUCTORS
+// ============================================================================
+
+/// Create a new empty schema for a table
+pub fn new(source: String) -> Schema {
+  Schema(
+    source: source,
+    table_schema: None,
+    fields: [],
+    primary_key: [],
+    table_constraints: [],
+    comment: None,
+  )
+}
+
+/// Create a new schema with a specific database schema/namespace
+pub fn new_with_schema(source: String, table_schema: String) -> Schema {
+  Schema(
+    source: source,
+    table_schema: Some(table_schema),
+    fields: [],
+    primary_key: [],
+    table_constraints: [],
+    comment: None,
+  )
+}
+
+// ============================================================================
+// SCHEMA BUILDERS (Pipeline-friendly)
+// ============================================================================
+
+/// Add a field to the schema
+/// Fields are added in order and the order is preserved
+pub fn add_field(schema: Schema, new_field: Field) -> Schema {
+  // Add to end to preserve insertion order
+  Schema(..schema, fields: list.append(schema.fields, [new_field]))
+}
+
+/// Alias for add_field - more concise in pipelines
+pub fn field(schema: Schema, new_field: Field) -> Schema {
+  add_field(schema, new_field)
+}
+
+/// Set the primary key columns
+/// Supports composite primary keys
+pub fn primary_key(schema: Schema, columns: List(String)) -> Schema {
+  Schema(..schema, primary_key: columns)
+}
+
+/// Set a single-column primary key
+pub fn single_primary_key(schema: Schema, column: String) -> Schema {
+  Schema(..schema, primary_key: [column])
+}
+
+/// Set the table schema/namespace
+pub fn in_schema(schema: Schema, table_schema: String) -> Schema {
+  Schema(..schema, table_schema: Some(table_schema))
+}
+
+/// Add a table-level constraint
+pub fn add_constraint(schema: Schema, constraint: TableConstraint) -> Schema {
+  Schema(
+    ..schema,
+    table_constraints: list.append(schema.table_constraints, [constraint]),
+  )
+}
+
+/// Add a multi-column unique constraint
+pub fn unique_constraint(
+  schema: Schema,
+  name: String,
+  columns: List(String),
+) -> Schema {
+  add_constraint(schema, UniqueConstraint(name, columns))
+}
+
+/// Add an index
+pub fn index(
+  schema: Schema,
+  name: String,
+  columns: List(String),
+  unique: Bool,
+) -> Schema {
+  add_constraint(schema, Index(name, columns, unique))
+}
+
+/// Add a table-level check constraint
+pub fn table_check(schema: Schema, name: String, expression: String) -> Schema {
+  add_constraint(schema, TableCheck(name, expression))
+}
+
+/// Add a comment to the schema
+pub fn with_comment(schema: Schema, text: String) -> Schema {
+  Schema(..schema, comment: Some(text))
+}
+
+// ============================================================================
+// SCHEMA ACCESSORS
+// ============================================================================
+
+/// Get the source table name
+pub fn get_source(schema: Schema) -> String {
+  schema.source
+}
+
+/// Get the fully qualified table name (schema.table or just table)
+pub fn get_qualified_name(schema: Schema) -> String {
+  case schema.table_schema {
+    Some(s) -> s <> "." <> schema.source
+    None -> schema.source
+  }
+}
+
+/// Get all fields in order
+pub fn get_fields(schema: Schema) -> List(Field) {
+  schema.fields
+}
+
+/// Get field count
+pub fn field_count(schema: Schema) -> Int {
+  list.length(schema.fields)
+}
+
+/// Get the primary key columns
+pub fn get_primary_key(schema: Schema) -> List(String) {
+  schema.primary_key
+}
+
+/// Check if schema has a primary key defined
+pub fn has_primary_key(schema: Schema) -> Bool {
+  !list.is_empty(schema.primary_key)
+}
+
+/// Get a field by name
+pub fn get_field(schema: Schema, name: String) -> Option(Field) {
+  list.find(schema.fields, fn(f) { field.get_name(f) == name })
+  |> option.from_result
+}
+
+/// Check if schema has a field with the given name
+pub fn has_field(schema: Schema, name: String) -> Bool {
+  option.is_some(get_field(schema, name))
+}
+
+/// Get all field names in order
+pub fn field_names(schema: Schema) -> List(String) {
+  list.map(schema.fields, field.get_name)
+}
+
+/// Get fields that are part of the primary key
+pub fn primary_key_fields(schema: Schema) -> List(Field) {
+  list.filter(schema.fields, fn(f) {
+    list.contains(schema.primary_key, field.get_name(f))
+  })
+}
+
+/// Get fields that are NOT part of the primary key
+pub fn non_primary_key_fields(schema: Schema) -> List(Field) {
+  list.filter(schema.fields, fn(f) {
+    !list.contains(schema.primary_key, field.get_name(f))
+  })
+}
+
+/// Get all nullable fields
+pub fn nullable_fields(schema: Schema) -> List(Field) {
+  list.filter(schema.fields, field.is_nullable)
+}
+
+/// Get all required (non-nullable, no default) fields
+pub fn required_fields(schema: Schema) -> List(Field) {
+  list.filter(schema.fields, fn(f) {
+    !field.is_nullable(f) && option.is_none(f.default)
+  })
+}
+
+/// Get all auto-increment fields
+pub fn auto_increment_fields(schema: Schema) -> List(Field) {
+  list.filter(schema.fields, field.is_auto_increment)
+}
+
+/// Get fields with foreign key constraints
+pub fn foreign_key_fields(schema: Schema) -> List(Field) {
+  list.filter(schema.fields, fn(f) {
+    field.has_constraint(f, field.is_foreign_key_constraint)
+  })
+}
+
+// ============================================================================
+// SCHEMA TRANSFORMATIONS
+// ============================================================================
+
+/// Create a new schema with only the specified fields
+/// Useful for creating insert/update schemas without auto-generated fields
+pub fn select_fields(schema: Schema, names: List(String)) -> Schema {
+  let selected_fields =
+    list.filter(schema.fields, fn(f) { list.contains(names, field.get_name(f)) })
+  Schema(..schema, fields: selected_fields)
+}
+
+/// Create a new schema excluding the specified fields
+/// Useful for creating public schemas without sensitive fields
+pub fn exclude_fields(schema: Schema, names: List(String)) -> Schema {
+  let remaining_fields =
+    list.filter(schema.fields, fn(f) {
+      !list.contains(names, field.get_name(f))
+    })
+  Schema(..schema, fields: remaining_fields)
+}
+
+/// Create a new schema with only non-auto-generated fields
+/// Useful for insert schemas
+pub fn insertable_fields(schema: Schema) -> Schema {
+  let fields = list.filter(schema.fields, fn(f) { !field.is_auto_increment(f) })
+  Schema(..schema, fields: fields)
+}
+
+/// Rename a field in the schema
+pub fn rename_field(
+  schema: Schema,
+  old_name: String,
+  new_name: String,
+) -> Schema {
+  let updated_fields =
+    list.map(schema.fields, fn(f) {
+      case field.get_name(f) == old_name {
+        True -> field.Field(..f, name: new_name)
+        False -> f
+      }
+    })
+  Schema(..schema, fields: updated_fields)
+}
+
+// ============================================================================
+// SCHEMA VALIDATION
+// ============================================================================
+
+/// Validation errors for schemas
+pub type SchemaError {
+  /// Primary key references non-existent field
+  InvalidPrimaryKey(column: String)
+
+  /// Duplicate field name
+  DuplicateField(name: String)
+
+  /// Empty schema (no fields)
+  EmptySchema
+
+  /// Invalid table name
+  InvalidTableName(name: String)
+
+  /// Table constraint references invalid column
+  InvalidConstraintColumn(constraint_name: String, column: String)
+}
+
+/// Validate a schema and return any errors
+pub fn validate(schema: Schema) -> List(SchemaError) {
+  let errors = []
+
+  // Check for empty table name
+  let errors = case string.is_empty(schema.source) {
+    True -> [InvalidTableName(""), ..errors]
+    False -> errors
+  }
+
+  // Check for empty schema
+  let errors = case list.is_empty(schema.fields) {
+    True -> [EmptySchema, ..errors]
+    False -> errors
+  }
+
+  // Check for duplicate field names
+  let field_name_list = field_names(schema)
+  let errors = check_duplicates(field_name_list, errors)
+
+  // Check primary key references valid fields
+  let errors =
+    list.fold(schema.primary_key, errors, fn(errs, pk_col) {
+      case has_field(schema, pk_col) {
+        True -> errs
+        False -> [InvalidPrimaryKey(pk_col), ..errs]
+      }
+    })
+
+  // Check table constraints reference valid columns
+  let errors =
+    list.fold(schema.table_constraints, errors, fn(errs, constraint) {
+      case constraint {
+        UniqueConstraint(name, columns) ->
+          validate_constraint_columns(name, columns, schema, errs)
+        Index(name, columns, _) ->
+          validate_constraint_columns(name, columns, schema, errs)
+        TableCheck(_, _) -> errs
+        CompositeForeignKey(name, columns, _, _) ->
+          validate_constraint_columns(name, columns, schema, errs)
+      }
+    })
+
+  list.reverse(errors)
+}
+
+/// Check if schema is valid
+pub fn is_valid(schema: Schema) -> Bool {
+  list.is_empty(validate(schema))
+}
+
+// Helper: check for duplicate field names
+fn check_duplicates(
+  names: List(String),
+  errors: List(SchemaError),
+) -> List(SchemaError) {
+  case names {
+    [] -> errors
+    [name, ..rest] ->
+      case list.contains(rest, name) {
+        True -> check_duplicates(rest, [DuplicateField(name), ..errors])
+        False -> check_duplicates(rest, errors)
+      }
+  }
+}
+
+// Helper: validate constraint columns exist
+fn validate_constraint_columns(
+  constraint_name: String,
+  columns: List(String),
+  schema: Schema,
+  errors: List(SchemaError),
+) -> List(SchemaError) {
+  list.fold(columns, errors, fn(errs, col) {
+    case has_field(schema, col) {
+      True -> errs
+      False -> [InvalidConstraintColumn(constraint_name, col), ..errs]
+    }
+  })
+}
+
+// ============================================================================
+// SCHEMA COMPARISON
+// ============================================================================
+
+/// Compare two schemas and find differences
+/// Useful for schema migration planning
+pub type SchemaDiff {
+  FieldAdded(Field)
+  FieldRemoved(String)
+  FieldTypeChanged(name: String, old_type: FieldType, new_type: FieldType)
+  PrimaryKeyChanged(old_pk: List(String), new_pk: List(String))
+}
+
+/// Find differences between two schemas
+pub fn diff(old_schema: Schema, new_schema: Schema) -> List(SchemaDiff) {
+  let diffs = []
+
+  // Find added fields
+  let old_names = field_names(old_schema)
+  let added_diffs =
+    list.filter_map(new_schema.fields, fn(f) {
+      case list.contains(old_names, field.get_name(f)) {
+        True -> Error(Nil)
+        False -> Ok(FieldAdded(f))
+      }
+    })
+
+  // Find removed fields
+  let new_names = field_names(new_schema)
+  let removed_diffs =
+    list.filter_map(old_schema.fields, fn(f) {
+      let name = field.get_name(f)
+      case list.contains(new_names, name) {
+        True -> Error(Nil)
+        False -> Ok(FieldRemoved(name))
+      }
+    })
+
+  // Find type changes
+  let type_change_diffs =
+    list.filter_map(old_schema.fields, fn(old_field) {
+      let name = field.get_name(old_field)
+      case get_field(new_schema, name) {
+        None -> Error(Nil)
+        Some(new_field) -> {
+          let old_type = field.get_type(old_field)
+          let new_type = field.get_type(new_field)
+          case old_type == new_type {
+            True -> Error(Nil)
+            False -> Ok(FieldTypeChanged(name, old_type, new_type))
+          }
+        }
+      }
+    })
+
+  // Check primary key changes
+  let pk_diffs = case old_schema.primary_key == new_schema.primary_key {
+    True -> []
+    False -> [PrimaryKeyChanged(old_schema.primary_key, new_schema.primary_key)]
+  }
+
+  list.flatten([diffs, added_diffs, removed_diffs, type_change_diffs, pk_diffs])
+}

--- a/src/cquill/schema/field.gleam
+++ b/src/cquill/schema/field.gleam
@@ -1,0 +1,499 @@
+// cquill Schema Field Types
+//
+// This module defines field types and metadata for database schemas.
+// It is part of the Schema layer which is PURE — no I/O, no side effects.
+//
+// The types here map to common SQL database types while remaining
+// database-agnostic. Adapters are responsible for translating these
+// to their specific SQL dialects.
+
+import gleam/dynamic.{type Dynamic}
+import gleam/list
+import gleam/option.{type Option, None, Some}
+import gleam/string
+
+// ============================================================================
+// FIELD TYPES
+// ============================================================================
+
+/// Represents the type of a database field.
+/// These map to common SQL types across different databases.
+pub type FieldType {
+  /// Integer type (32-bit signed)
+  /// SQL: INTEGER, INT, INT4
+  Integer
+
+  /// Big integer type (64-bit signed)
+  /// SQL: BIGINT, INT8, BIGSERIAL
+  BigInteger
+
+  /// Floating point number
+  /// SQL: FLOAT, DOUBLE PRECISION, REAL
+  Float
+
+  /// Decimal/numeric with precision
+  /// SQL: DECIMAL, NUMERIC
+  Decimal(precision: Int, scale: Int)
+
+  /// Variable-length string
+  /// SQL: VARCHAR, TEXT, CHARACTER VARYING
+  String
+
+  /// Fixed-length string
+  /// SQL: CHAR, CHARACTER
+  Char(length: Int)
+
+  /// Boolean value
+  /// SQL: BOOLEAN, BOOL
+  Boolean
+
+  /// Timestamp with timezone
+  /// SQL: TIMESTAMP WITH TIME ZONE, TIMESTAMPTZ
+  DateTime
+
+  /// Date only (no time)
+  /// SQL: DATE
+  Date
+
+  /// Time only (no date)
+  /// SQL: TIME, TIME WITHOUT TIME ZONE
+  Time
+
+  /// Binary data
+  /// SQL: BYTEA, BLOB, BINARY
+  Binary
+
+  /// UUID/GUID
+  /// SQL: UUID
+  Uuid
+
+  /// JSON data
+  /// SQL: JSON, JSONB
+  Json
+
+  /// Array of another type
+  /// SQL: type[], ARRAY
+  Array(FieldType)
+
+  /// Nullable wrapper - field can be NULL
+  /// This is separate from constraints to allow type composition
+  Nullable(FieldType)
+
+  /// Enum type with allowed values
+  /// SQL: ENUM (Postgres), CHECK constraint (others)
+  Enum(name: String, values: List(String))
+
+  /// Custom/adapter-specific type
+  /// For types not covered by the standard set
+  Custom(type_name: String)
+}
+
+// ============================================================================
+// FIELD CONSTRAINTS
+// ============================================================================
+
+/// Constraints that can be applied to fields
+pub type Constraint {
+  /// Field cannot be NULL
+  NotNull
+
+  /// Field must have unique values (per-column unique)
+  Unique
+
+  /// Field is the primary key (or part of composite key)
+  PrimaryKey
+
+  /// Field references another table
+  ForeignKey(table: String, column: String, on_delete: ForeignKeyAction)
+
+  /// Custom check constraint
+  Check(name: String, expression: String)
+
+  /// Minimum value constraint (for numeric types)
+  MinValue(min: Int)
+
+  /// Maximum value constraint (for numeric types)
+  MaxValue(max: Int)
+
+  /// Minimum length constraint (for string types)
+  MinLength(min: Int)
+
+  /// Maximum length constraint (for string types)
+  MaxLength(max: Int)
+
+  /// Regex pattern constraint (for string types)
+  Pattern(regex: String)
+}
+
+/// Actions for foreign key ON DELETE/ON UPDATE
+pub type ForeignKeyAction {
+  NoAction
+  Restrict
+  Cascade
+  SetNull
+  SetDefault
+}
+
+// ============================================================================
+// DEFAULT VALUES
+// ============================================================================
+
+/// Default value for a field
+pub type Default {
+  /// Static default value
+  DefaultValue(Dynamic)
+
+  /// Database function as default (e.g., "now()", "gen_random_uuid()")
+  DefaultFunction(function_name: String)
+
+  /// Use database's auto-increment/serial
+  DefaultAutoIncrement
+}
+
+// ============================================================================
+// FIELD DEFINITION
+// ============================================================================
+
+/// Complete field definition with all metadata
+pub type Field {
+  Field(
+    /// Field name (column name in database)
+    name: String,
+    /// Field type
+    field_type: FieldType,
+    /// Default value if any
+    default: Option(Default),
+    /// Constraints applied to this field
+    constraints: List(Constraint),
+    /// Documentation/comment for this field
+    comment: Option(String),
+  )
+}
+
+// ============================================================================
+// FIELD CONSTRUCTORS
+// ============================================================================
+
+/// Create a new field with just name and type
+pub fn new(name: String, field_type: FieldType) -> Field {
+  Field(
+    name: name,
+    field_type: field_type,
+    default: None,
+    constraints: [],
+    comment: None,
+  )
+}
+
+/// Create an integer field
+pub fn integer(name: String) -> Field {
+  new(name, Integer)
+}
+
+/// Create a big integer field
+pub fn big_integer(name: String) -> Field {
+  new(name, BigInteger)
+}
+
+/// Create a float field
+pub fn float(name: String) -> Field {
+  new(name, Float)
+}
+
+/// Create a decimal field with precision and scale
+pub fn decimal(name: String, precision: Int, scale: Int) -> Field {
+  new(name, Decimal(precision, scale))
+}
+
+/// Create a string/text field
+pub fn string(name: String) -> Field {
+  new(name, String)
+}
+
+/// Create a boolean field
+pub fn boolean(name: String) -> Field {
+  new(name, Boolean)
+}
+
+/// Create a datetime/timestamp field
+pub fn datetime(name: String) -> Field {
+  new(name, DateTime)
+}
+
+/// Create a date-only field
+pub fn date(name: String) -> Field {
+  new(name, Date)
+}
+
+/// Create a time-only field
+pub fn time(name: String) -> Field {
+  new(name, Time)
+}
+
+/// Create a binary/bytea field
+pub fn binary(name: String) -> Field {
+  new(name, Binary)
+}
+
+/// Create a UUID field
+pub fn uuid(name: String) -> Field {
+  new(name, Uuid)
+}
+
+/// Create a JSON field
+pub fn json(name: String) -> Field {
+  new(name, Json)
+}
+
+/// Create an array field
+pub fn array(name: String, element_type: FieldType) -> Field {
+  new(name, Array(element_type))
+}
+
+/// Create an enum field
+pub fn enum_(name: String, enum_name: String, values: List(String)) -> Field {
+  new(name, Enum(enum_name, values))
+}
+
+// ============================================================================
+// FIELD MODIFIERS (Pipeline-friendly)
+// ============================================================================
+
+/// Mark field as nullable
+pub fn nullable(field: Field) -> Field {
+  Field(..field, field_type: Nullable(field.field_type))
+}
+
+/// Add a default value
+pub fn with_default(field: Field, default: Default) -> Field {
+  Field(..field, default: Some(default))
+}
+
+/// Add a static default value
+pub fn default_value(field: Field, value: Dynamic) -> Field {
+  Field(..field, default: Some(DefaultValue(value)))
+}
+
+/// Add a database function as default
+pub fn default_function(field: Field, function_name: String) -> Field {
+  Field(..field, default: Some(DefaultFunction(function_name)))
+}
+
+/// Mark field as auto-increment
+pub fn auto_increment(field: Field) -> Field {
+  Field(..field, default: Some(DefaultAutoIncrement))
+}
+
+/// Add NOT NULL constraint
+pub fn not_null(field: Field) -> Field {
+  Field(..field, constraints: [NotNull, ..field.constraints])
+}
+
+/// Add UNIQUE constraint
+pub fn unique(field: Field) -> Field {
+  Field(..field, constraints: [Unique, ..field.constraints])
+}
+
+/// Mark as primary key
+pub fn primary_key(field: Field) -> Field {
+  Field(..field, constraints: [PrimaryKey, ..field.constraints])
+}
+
+/// Add foreign key constraint
+pub fn references(field: Field, table: String, column: String) -> Field {
+  let fk = ForeignKey(table: table, column: column, on_delete: NoAction)
+  Field(..field, constraints: [fk, ..field.constraints])
+}
+
+/// Add foreign key with ON DELETE action
+pub fn references_with_action(
+  field: Field,
+  table: String,
+  column: String,
+  on_delete: ForeignKeyAction,
+) -> Field {
+  let fk = ForeignKey(table: table, column: column, on_delete: on_delete)
+  Field(..field, constraints: [fk, ..field.constraints])
+}
+
+/// Add check constraint
+pub fn check(field: Field, name: String, expression: String) -> Field {
+  Field(..field, constraints: [Check(name, expression), ..field.constraints])
+}
+
+/// Add minimum value constraint
+pub fn min_value(field: Field, min: Int) -> Field {
+  Field(..field, constraints: [MinValue(min), ..field.constraints])
+}
+
+/// Add maximum value constraint
+pub fn max_value(field: Field, max: Int) -> Field {
+  Field(..field, constraints: [MaxValue(max), ..field.constraints])
+}
+
+/// Add minimum length constraint
+pub fn min_length(field: Field, min: Int) -> Field {
+  Field(..field, constraints: [MinLength(min), ..field.constraints])
+}
+
+/// Add maximum length constraint
+pub fn max_length(field: Field, max: Int) -> Field {
+  Field(..field, constraints: [MaxLength(max), ..field.constraints])
+}
+
+/// Add regex pattern constraint
+pub fn pattern(field: Field, regex: String) -> Field {
+  Field(..field, constraints: [Pattern(regex), ..field.constraints])
+}
+
+/// Add a comment/documentation
+pub fn comment(field: Field, text: String) -> Field {
+  Field(..field, comment: Some(text))
+}
+
+// ============================================================================
+// FIELD ACCESSORS
+// ============================================================================
+
+/// Get the field name
+pub fn get_name(field: Field) -> String {
+  field.name
+}
+
+/// Get the field type
+pub fn get_type(field: Field) -> FieldType {
+  field.field_type
+}
+
+/// Get the field's base type (unwrapping Nullable if present)
+pub fn get_base_type(field: Field) -> FieldType {
+  case field.field_type {
+    Nullable(inner) -> inner
+    other -> other
+  }
+}
+
+/// Check if field is nullable
+pub fn is_nullable(field: Field) -> Bool {
+  case field.field_type {
+    Nullable(_) -> True
+    _ -> !has_constraint(field, is_not_null_constraint)
+  }
+}
+
+/// Check if field is a primary key
+pub fn is_primary_key(field: Field) -> Bool {
+  has_constraint(field, is_primary_key_constraint)
+}
+
+/// Check if field has auto-increment
+pub fn is_auto_increment(field: Field) -> Bool {
+  case field.default {
+    Some(DefaultAutoIncrement) -> True
+    _ -> False
+  }
+}
+
+/// Check if field has a specific constraint
+pub fn has_constraint(field: Field, predicate: fn(Constraint) -> Bool) -> Bool {
+  list.any(field.constraints, predicate)
+}
+
+/// Get all constraints of a specific type
+pub fn get_constraints(
+  field: Field,
+  predicate: fn(Constraint) -> Bool,
+) -> List(Constraint) {
+  list.filter(field.constraints, predicate)
+}
+
+// ============================================================================
+// CONSTRAINT PREDICATES
+// ============================================================================
+
+/// Check if constraint is NotNull
+pub fn is_not_null_constraint(constraint: Constraint) -> Bool {
+  case constraint {
+    NotNull -> True
+    _ -> False
+  }
+}
+
+/// Check if constraint is PrimaryKey
+pub fn is_primary_key_constraint(constraint: Constraint) -> Bool {
+  case constraint {
+    PrimaryKey -> True
+    _ -> False
+  }
+}
+
+/// Check if constraint is Unique
+pub fn is_unique_constraint(constraint: Constraint) -> Bool {
+  case constraint {
+    Unique -> True
+    _ -> False
+  }
+}
+
+/// Check if constraint is ForeignKey
+pub fn is_foreign_key_constraint(constraint: Constraint) -> Bool {
+  case constraint {
+    ForeignKey(..) -> True
+    _ -> False
+  }
+}
+
+// ============================================================================
+// TYPE UTILITIES
+// ============================================================================
+
+/// Get a human-readable name for a field type
+pub fn type_name(field_type: FieldType) -> String {
+  case field_type {
+    Integer -> "integer"
+    BigInteger -> "bigint"
+    Float -> "float"
+    Decimal(p, s) ->
+      "decimal(" <> string.inspect(p) <> "," <> string.inspect(s) <> ")"
+    String -> "string"
+    Char(l) -> "char(" <> string.inspect(l) <> ")"
+    Boolean -> "boolean"
+    DateTime -> "datetime"
+    Date -> "date"
+    Time -> "time"
+    Binary -> "binary"
+    Uuid -> "uuid"
+    Json -> "json"
+    Array(inner) -> "array(" <> type_name(inner) <> ")"
+    Nullable(inner) -> type_name(inner) <> "?"
+    Enum(name, _) -> "enum:" <> name
+    Custom(name) -> "custom:" <> name
+  }
+}
+
+/// Check if a field type is numeric
+pub fn is_numeric_type(field_type: FieldType) -> Bool {
+  case field_type {
+    Integer | BigInteger | Float | Decimal(..) -> True
+    Nullable(inner) -> is_numeric_type(inner)
+    _ -> False
+  }
+}
+
+/// Check if a field type is text-like
+pub fn is_text_type(field_type: FieldType) -> Bool {
+  case field_type {
+    String | Char(_) -> True
+    Nullable(inner) -> is_text_type(inner)
+    _ -> False
+  }
+}
+
+/// Check if a field type is temporal (date/time related)
+pub fn is_temporal_type(field_type: FieldType) -> Bool {
+  case field_type {
+    DateTime | Date | Time -> True
+    Nullable(inner) -> is_temporal_type(inner)
+    _ -> False
+  }
+}

--- a/test/cquill/schema/field_test.gleam
+++ b/test/cquill/schema/field_test.gleam
@@ -1,0 +1,376 @@
+import cquill/schema/field.{
+  Array, BigInteger, Boolean, Cascade, Char, Check, Custom, Date, DateTime,
+  Decimal, DefaultAutoIncrement, DefaultFunction, DefaultValue, Enum, Float,
+  ForeignKey, Integer, Json, MaxLength, MaxValue, MinLength, MinValue, NoAction,
+  NotNull, Nullable, Pattern, PrimaryKey, Restrict, SetNull, String, Time,
+  Unique, Uuid,
+}
+import gleam/dynamic
+import gleam/option.{None, Some}
+import gleeunit
+import gleeunit/should
+
+pub fn main() {
+  gleeunit.main()
+}
+
+// ============================================================================
+// FIELD CONSTRUCTOR TESTS
+// ============================================================================
+
+pub fn integer_field_test() {
+  let f = field.integer("id")
+
+  field.get_name(f) |> should.equal("id")
+  field.get_type(f) |> should.equal(Integer)
+  f.default |> should.equal(None)
+  f.constraints |> should.equal([])
+}
+
+pub fn string_field_test() {
+  let f = field.string("email")
+
+  field.get_name(f) |> should.equal("email")
+  field.get_type(f) |> should.equal(String)
+}
+
+pub fn big_integer_field_test() {
+  let f = field.big_integer("count")
+
+  field.get_type(f) |> should.equal(BigInteger)
+}
+
+pub fn float_field_test() {
+  let f = field.float("price")
+
+  field.get_type(f) |> should.equal(Float)
+}
+
+pub fn decimal_field_test() {
+  let f = field.decimal("amount", 10, 2)
+
+  field.get_type(f) |> should.equal(Decimal(10, 2))
+}
+
+pub fn boolean_field_test() {
+  let f = field.boolean("active")
+
+  field.get_type(f) |> should.equal(Boolean)
+}
+
+pub fn datetime_field_test() {
+  let f = field.datetime("created_at")
+
+  field.get_type(f) |> should.equal(DateTime)
+}
+
+pub fn date_field_test() {
+  let f = field.date("birth_date")
+
+  field.get_type(f) |> should.equal(Date)
+}
+
+pub fn time_field_test() {
+  let f = field.time("start_time")
+
+  field.get_type(f) |> should.equal(Time)
+}
+
+pub fn uuid_field_test() {
+  let f = field.uuid("external_id")
+
+  field.get_type(f) |> should.equal(Uuid)
+}
+
+pub fn json_field_test() {
+  let f = field.json("metadata")
+
+  field.get_type(f) |> should.equal(Json)
+}
+
+pub fn binary_field_test() {
+  let f = field.binary("data")
+
+  field.get_type(f) |> should.equal(field.Binary)
+}
+
+pub fn array_field_test() {
+  let f = field.array("tags", String)
+
+  field.get_type(f) |> should.equal(Array(String))
+}
+
+pub fn enum_field_test() {
+  let f =
+    field.enum_("status", "order_status", ["pending", "shipped", "delivered"])
+
+  field.get_type(f)
+  |> should.equal(Enum("order_status", ["pending", "shipped", "delivered"]))
+}
+
+// ============================================================================
+// FIELD MODIFIER TESTS
+// ============================================================================
+
+pub fn nullable_modifier_test() {
+  let f =
+    field.string("name")
+    |> field.nullable
+
+  field.get_type(f) |> should.equal(Nullable(String))
+  field.is_nullable(f) |> should.be_true
+}
+
+pub fn not_null_constraint_test() {
+  let f =
+    field.string("email")
+    |> field.not_null
+
+  field.has_constraint(f, field.is_not_null_constraint) |> should.be_true
+  field.is_nullable(f) |> should.be_false
+}
+
+pub fn unique_constraint_test() {
+  let f =
+    field.string("email")
+    |> field.unique
+
+  field.has_constraint(f, field.is_unique_constraint) |> should.be_true
+}
+
+pub fn primary_key_constraint_test() {
+  let f =
+    field.integer("id")
+    |> field.primary_key
+
+  field.has_constraint(f, field.is_primary_key_constraint) |> should.be_true
+  field.is_primary_key(f) |> should.be_true
+}
+
+pub fn foreign_key_constraint_test() {
+  let f =
+    field.integer("user_id")
+    |> field.references("users", "id")
+
+  field.has_constraint(f, field.is_foreign_key_constraint) |> should.be_true
+}
+
+pub fn foreign_key_with_action_test() {
+  let f =
+    field.integer("user_id")
+    |> field.references_with_action("users", "id", Cascade)
+
+  let fk_constraints = field.get_constraints(f, field.is_foreign_key_constraint)
+  case fk_constraints {
+    [ForeignKey(_, _, on_delete)] -> on_delete |> should.equal(Cascade)
+    _ -> should.fail()
+  }
+}
+
+pub fn check_constraint_test() {
+  let f =
+    field.integer("age")
+    |> field.check("age_positive", "age > 0")
+
+  let check_pred = fn(c) {
+    case c {
+      Check(_, _) -> True
+      _ -> False
+    }
+  }
+  field.has_constraint(f, check_pred) |> should.be_true
+}
+
+pub fn min_max_value_test() {
+  let f =
+    field.integer("quantity")
+    |> field.min_value(0)
+    |> field.max_value(1000)
+
+  let min_pred = fn(c) {
+    case c {
+      MinValue(_) -> True
+      _ -> False
+    }
+  }
+  let max_pred = fn(c) {
+    case c {
+      MaxValue(_) -> True
+      _ -> False
+    }
+  }
+  field.has_constraint(f, min_pred) |> should.be_true
+  field.has_constraint(f, max_pred) |> should.be_true
+}
+
+pub fn min_max_length_test() {
+  let f =
+    field.string("username")
+    |> field.min_length(3)
+    |> field.max_length(50)
+
+  let min_pred = fn(c) {
+    case c {
+      MinLength(_) -> True
+      _ -> False
+    }
+  }
+  let max_pred = fn(c) {
+    case c {
+      MaxLength(_) -> True
+      _ -> False
+    }
+  }
+  field.has_constraint(f, min_pred) |> should.be_true
+  field.has_constraint(f, max_pred) |> should.be_true
+}
+
+pub fn pattern_constraint_test() {
+  let f =
+    field.string("email")
+    |> field.pattern("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$")
+
+  let pattern_pred = fn(c) {
+    case c {
+      Pattern(_) -> True
+      _ -> False
+    }
+  }
+  field.has_constraint(f, pattern_pred) |> should.be_true
+}
+
+// ============================================================================
+// DEFAULT VALUE TESTS
+// ============================================================================
+
+pub fn default_value_test() {
+  let f =
+    field.boolean("active")
+    |> field.default_value(dynamic.bool(True))
+
+  case f.default {
+    Some(DefaultValue(_)) -> should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+pub fn default_function_test() {
+  let f =
+    field.datetime("created_at")
+    |> field.default_function("now()")
+
+  case f.default {
+    Some(DefaultFunction("now()")) -> should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+pub fn auto_increment_test() {
+  let f =
+    field.integer("id")
+    |> field.auto_increment
+
+  field.is_auto_increment(f) |> should.be_true
+  case f.default {
+    Some(DefaultAutoIncrement) -> should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+// ============================================================================
+// COMMENT TEST
+// ============================================================================
+
+pub fn comment_test() {
+  let f =
+    field.string("email")
+    |> field.comment("User's primary email address")
+
+  f.comment |> should.equal(Some("User's primary email address"))
+}
+
+// ============================================================================
+// TYPE UTILITY TESTS
+// ============================================================================
+
+pub fn type_name_test() {
+  field.type_name(Integer) |> should.equal("integer")
+  field.type_name(String) |> should.equal("string")
+  field.type_name(Nullable(String)) |> should.equal("string?")
+  field.type_name(Array(Integer)) |> should.equal("array(integer)")
+  field.type_name(Decimal(10, 2)) |> should.equal("decimal(10,2)")
+  field.type_name(Enum("status", [])) |> should.equal("enum:status")
+  field.type_name(Custom("geometry")) |> should.equal("custom:geometry")
+}
+
+pub fn is_numeric_type_test() {
+  field.is_numeric_type(Integer) |> should.be_true
+  field.is_numeric_type(BigInteger) |> should.be_true
+  field.is_numeric_type(Float) |> should.be_true
+  field.is_numeric_type(Decimal(10, 2)) |> should.be_true
+  field.is_numeric_type(Nullable(Integer)) |> should.be_true
+  field.is_numeric_type(String) |> should.be_false
+}
+
+pub fn is_text_type_test() {
+  field.is_text_type(String) |> should.be_true
+  field.is_text_type(Char(10)) |> should.be_true
+  field.is_text_type(Nullable(String)) |> should.be_true
+  field.is_text_type(Integer) |> should.be_false
+}
+
+pub fn is_temporal_type_test() {
+  field.is_temporal_type(DateTime) |> should.be_true
+  field.is_temporal_type(Date) |> should.be_true
+  field.is_temporal_type(Time) |> should.be_true
+  field.is_temporal_type(Nullable(DateTime)) |> should.be_true
+  field.is_temporal_type(String) |> should.be_false
+}
+
+pub fn get_base_type_test() {
+  let f = field.string("name") |> field.nullable
+
+  field.get_base_type(f) |> should.equal(String)
+
+  let f2 = field.integer("count")
+  field.get_base_type(f2) |> should.equal(Integer)
+}
+
+// ============================================================================
+// MULTIPLE CONSTRAINTS TEST
+// ============================================================================
+
+pub fn multiple_constraints_test() {
+  let f =
+    field.string("email")
+    |> field.not_null
+    |> field.unique
+    |> field.max_length(255)
+
+  // Should have all three constraints
+  field.has_constraint(f, field.is_not_null_constraint) |> should.be_true
+  field.has_constraint(f, field.is_unique_constraint) |> should.be_true
+
+  let max_pred = fn(c) {
+    case c {
+      MaxLength(255) -> True
+      _ -> False
+    }
+  }
+  field.has_constraint(f, max_pred) |> should.be_true
+}
+
+// ============================================================================
+// FOREIGN KEY ACTION TESTS
+// ============================================================================
+
+pub fn foreign_key_actions_test() {
+  // Test all action types compile and are distinct
+  let _no_action = NoAction
+  let _restrict = Restrict
+  let _cascade = Cascade
+  let _set_null = SetNull
+  let _set_default = field.SetDefault
+
+  should.be_true(True)
+}

--- a/test/cquill/schema_test.gleam
+++ b/test/cquill/schema_test.gleam
@@ -1,0 +1,578 @@
+import cquill/schema.{
+  type Schema, type SchemaDiff, type SchemaError, CompositeForeignKey,
+  DuplicateField, EmptySchema, FieldAdded, FieldRemoved, FieldTypeChanged, Index,
+  InvalidConstraintColumn, InvalidPrimaryKey, InvalidTableName,
+  PrimaryKeyChanged, TableCheck, UniqueConstraint,
+}
+import cquill/schema/field.{Integer, Nullable, String}
+import gleam/dynamic
+import gleam/list
+import gleam/option.{None, Some}
+import gleeunit
+import gleeunit/should
+
+pub fn main() {
+  gleeunit.main()
+}
+
+// ============================================================================
+// SCHEMA CONSTRUCTOR TESTS
+// ============================================================================
+
+pub fn new_schema_test() {
+  let s = schema.new("users")
+
+  schema.get_source(s) |> should.equal("users")
+  schema.get_fields(s) |> should.equal([])
+  schema.get_primary_key(s) |> should.equal([])
+  s.table_schema |> should.equal(None)
+}
+
+pub fn new_with_schema_test() {
+  let s = schema.new_with_schema("users", "public")
+
+  schema.get_source(s) |> should.equal("users")
+  s.table_schema |> should.equal(Some("public"))
+  schema.get_qualified_name(s) |> should.equal("public.users")
+}
+
+pub fn qualified_name_without_schema_test() {
+  let s = schema.new("users")
+
+  schema.get_qualified_name(s) |> should.equal("users")
+}
+
+// ============================================================================
+// FIELD ADDITION TESTS
+// ============================================================================
+
+pub fn add_single_field_test() {
+  let s =
+    schema.new("users")
+    |> schema.field(field.integer("id"))
+
+  schema.field_count(s) |> should.equal(1)
+  schema.has_field(s, "id") |> should.be_true
+}
+
+pub fn add_multiple_fields_test() {
+  let s =
+    schema.new("users")
+    |> schema.field(field.integer("id"))
+    |> schema.field(field.string("email"))
+    |> schema.field(field.string("name") |> field.nullable)
+
+  schema.field_count(s) |> should.equal(3)
+  schema.has_field(s, "id") |> should.be_true
+  schema.has_field(s, "email") |> should.be_true
+  schema.has_field(s, "name") |> should.be_true
+}
+
+pub fn field_order_preserved_test() {
+  let s =
+    schema.new("users")
+    |> schema.field(field.integer("id"))
+    |> schema.field(field.string("email"))
+    |> schema.field(field.string("name"))
+
+  schema.field_names(s) |> should.equal(["id", "email", "name"])
+}
+
+pub fn get_field_test() {
+  let s =
+    schema.new("users")
+    |> schema.field(field.integer("id"))
+    |> schema.field(field.string("email"))
+
+  case schema.get_field(s, "email") {
+    Some(f) -> field.get_name(f) |> should.equal("email")
+    None -> should.fail()
+  }
+
+  schema.get_field(s, "nonexistent") |> should.equal(None)
+}
+
+// ============================================================================
+// PRIMARY KEY TESTS
+// ============================================================================
+
+pub fn single_primary_key_test() {
+  let s =
+    schema.new("users")
+    |> schema.field(field.integer("id"))
+    |> schema.single_primary_key("id")
+
+  schema.get_primary_key(s) |> should.equal(["id"])
+  schema.has_primary_key(s) |> should.be_true
+}
+
+pub fn composite_primary_key_test() {
+  let s =
+    schema.new("user_roles")
+    |> schema.field(field.integer("user_id"))
+    |> schema.field(field.integer("role_id"))
+    |> schema.primary_key(["user_id", "role_id"])
+
+  schema.get_primary_key(s) |> should.equal(["user_id", "role_id"])
+}
+
+pub fn no_primary_key_test() {
+  let s = schema.new("logs")
+
+  schema.has_primary_key(s) |> should.be_false
+}
+
+pub fn primary_key_fields_test() {
+  let s =
+    schema.new("users")
+    |> schema.field(field.integer("id"))
+    |> schema.field(field.string("email"))
+    |> schema.single_primary_key("id")
+
+  let pk_fields = schema.primary_key_fields(s)
+  pk_fields |> list.length |> should.equal(1)
+  case pk_fields {
+    [f] -> field.get_name(f) |> should.equal("id")
+    _ -> should.fail()
+  }
+}
+
+pub fn non_primary_key_fields_test() {
+  let s =
+    schema.new("users")
+    |> schema.field(field.integer("id"))
+    |> schema.field(field.string("email"))
+    |> schema.field(field.string("name"))
+    |> schema.single_primary_key("id")
+
+  let non_pk_fields = schema.non_primary_key_fields(s)
+  non_pk_fields |> list.length |> should.equal(2)
+
+  let names = list.map(non_pk_fields, field.get_name)
+  names |> should.equal(["email", "name"])
+}
+
+// ============================================================================
+// TABLE CONSTRAINT TESTS
+// ============================================================================
+
+pub fn unique_constraint_test() {
+  let s =
+    schema.new("users")
+    |> schema.field(field.string("email"))
+    |> schema.unique_constraint("users_email_unique", ["email"])
+
+  s.table_constraints |> list.length |> should.equal(1)
+  case s.table_constraints {
+    [UniqueConstraint(name, cols)] -> {
+      name |> should.equal("users_email_unique")
+      cols |> should.equal(["email"])
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn multi_column_unique_test() {
+  let s =
+    schema.new("user_roles")
+    |> schema.field(field.integer("user_id"))
+    |> schema.field(field.integer("role_id"))
+    |> schema.unique_constraint("user_roles_unique", ["user_id", "role_id"])
+
+  case s.table_constraints {
+    [UniqueConstraint(_, cols)] -> cols |> should.equal(["user_id", "role_id"])
+    _ -> should.fail()
+  }
+}
+
+pub fn index_test() {
+  let s =
+    schema.new("users")
+    |> schema.field(field.string("email"))
+    |> schema.index("users_email_idx", ["email"], False)
+
+  case s.table_constraints {
+    [Index(name, cols, unique)] -> {
+      name |> should.equal("users_email_idx")
+      cols |> should.equal(["email"])
+      unique |> should.be_false
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn table_check_constraint_test() {
+  let s =
+    schema.new("products")
+    |> schema.field(field.decimal("price", 10, 2))
+    |> schema.field(field.decimal("sale_price", 10, 2))
+    |> schema.table_check("price_check", "sale_price <= price")
+
+  case s.table_constraints {
+    [TableCheck(name, expr)] -> {
+      name |> should.equal("price_check")
+      expr |> should.equal("sale_price <= price")
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn schema_comment_test() {
+  let s =
+    schema.new("users")
+    |> schema.with_comment("Main user accounts table")
+
+  s.comment |> should.equal(Some("Main user accounts table"))
+}
+
+pub fn in_schema_test() {
+  let s =
+    schema.new("users")
+    |> schema.in_schema("auth")
+
+  s.table_schema |> should.equal(Some("auth"))
+  schema.get_qualified_name(s) |> should.equal("auth.users")
+}
+
+// ============================================================================
+// FIELD FILTERING TESTS
+// ============================================================================
+
+pub fn nullable_fields_test() {
+  let s =
+    schema.new("users")
+    |> schema.field(field.integer("id") |> field.not_null)
+    |> schema.field(field.string("email") |> field.not_null)
+    |> schema.field(field.string("name") |> field.nullable)
+    |> schema.field(field.string("bio") |> field.nullable)
+
+  let nullable = schema.nullable_fields(s)
+  nullable |> list.length |> should.equal(2)
+
+  let names = list.map(nullable, field.get_name)
+  list.contains(names, "name") |> should.be_true
+  list.contains(names, "bio") |> should.be_true
+}
+
+pub fn required_fields_test() {
+  let s =
+    schema.new("users")
+    |> schema.field(field.integer("id") |> field.auto_increment)
+    |> schema.field(field.string("email") |> field.not_null)
+    |> schema.field(field.string("name") |> field.nullable)
+    |> schema.field(
+      field.boolean("active") |> field.default_value(dynamic.bool(True)),
+    )
+
+  // Only email is required (not null, no default)
+  // id has auto_increment, name is nullable, active has default
+  let required = schema.required_fields(s)
+  required |> list.length |> should.equal(1)
+  case required {
+    [f] -> field.get_name(f) |> should.equal("email")
+    _ -> should.fail()
+  }
+}
+
+pub fn auto_increment_fields_test() {
+  let s =
+    schema.new("users")
+    |> schema.field(field.integer("id") |> field.auto_increment)
+    |> schema.field(field.string("email"))
+
+  let auto_inc = schema.auto_increment_fields(s)
+  auto_inc |> list.length |> should.equal(1)
+  case auto_inc {
+    [f] -> field.get_name(f) |> should.equal("id")
+    _ -> should.fail()
+  }
+}
+
+pub fn foreign_key_fields_test() {
+  let s =
+    schema.new("posts")
+    |> schema.field(field.integer("id"))
+    |> schema.field(field.integer("user_id") |> field.references("users", "id"))
+    |> schema.field(field.string("title"))
+
+  let fk_fields = schema.foreign_key_fields(s)
+  fk_fields |> list.length |> should.equal(1)
+  case fk_fields {
+    [f] -> field.get_name(f) |> should.equal("user_id")
+    _ -> should.fail()
+  }
+}
+
+// ============================================================================
+// SCHEMA TRANSFORMATION TESTS
+// ============================================================================
+
+pub fn select_fields_test() {
+  let full_schema =
+    schema.new("users")
+    |> schema.field(field.integer("id"))
+    |> schema.field(field.string("email"))
+    |> schema.field(field.string("password_hash"))
+    |> schema.field(field.string("name"))
+
+  let public_schema = schema.select_fields(full_schema, ["id", "email", "name"])
+
+  schema.field_count(public_schema) |> should.equal(3)
+  schema.has_field(public_schema, "password_hash") |> should.be_false
+}
+
+pub fn exclude_fields_test() {
+  let full_schema =
+    schema.new("users")
+    |> schema.field(field.integer("id"))
+    |> schema.field(field.string("email"))
+    |> schema.field(field.string("password_hash"))
+    |> schema.field(field.string("name"))
+
+  let public_schema = schema.exclude_fields(full_schema, ["password_hash"])
+
+  schema.field_count(public_schema) |> should.equal(3)
+  schema.has_field(public_schema, "password_hash") |> should.be_false
+  schema.has_field(public_schema, "email") |> should.be_true
+}
+
+pub fn insertable_fields_test() {
+  let full_schema =
+    schema.new("users")
+    |> schema.field(field.integer("id") |> field.auto_increment)
+    |> schema.field(field.string("email"))
+    |> schema.field(field.string("name"))
+
+  let insert_schema = schema.insertable_fields(full_schema)
+
+  schema.field_count(insert_schema) |> should.equal(2)
+  schema.has_field(insert_schema, "id") |> should.be_false
+  schema.has_field(insert_schema, "email") |> should.be_true
+}
+
+pub fn rename_field_test() {
+  let s =
+    schema.new("users")
+    |> schema.field(field.string("email"))
+    |> schema.rename_field("email", "email_address")
+
+  schema.has_field(s, "email") |> should.be_false
+  schema.has_field(s, "email_address") |> should.be_true
+}
+
+// ============================================================================
+// VALIDATION TESTS
+// ============================================================================
+
+pub fn valid_schema_test() {
+  let s =
+    schema.new("users")
+    |> schema.field(field.integer("id"))
+    |> schema.field(field.string("email"))
+    |> schema.single_primary_key("id")
+
+  schema.is_valid(s) |> should.be_true
+  schema.validate(s) |> should.equal([])
+}
+
+pub fn empty_schema_invalid_test() {
+  let s = schema.new("users")
+
+  schema.is_valid(s) |> should.be_false
+  let errors = schema.validate(s)
+  list.contains(errors, EmptySchema) |> should.be_true
+}
+
+pub fn empty_table_name_invalid_test() {
+  let s =
+    schema.new("")
+    |> schema.field(field.integer("id"))
+
+  schema.is_valid(s) |> should.be_false
+  let errors = schema.validate(s)
+  list.contains(errors, InvalidTableName("")) |> should.be_true
+}
+
+pub fn invalid_primary_key_test() {
+  let s =
+    schema.new("users")
+    |> schema.field(field.integer("id"))
+    |> schema.single_primary_key("nonexistent")
+
+  schema.is_valid(s) |> should.be_false
+  let errors = schema.validate(s)
+  list.contains(errors, InvalidPrimaryKey("nonexistent")) |> should.be_true
+}
+
+pub fn duplicate_field_invalid_test() {
+  let s =
+    schema.new("users")
+    |> schema.field(field.integer("id"))
+    |> schema.field(field.string("id"))
+  // Duplicate!
+
+  schema.is_valid(s) |> should.be_false
+  let errors = schema.validate(s)
+  list.contains(errors, DuplicateField("id")) |> should.be_true
+}
+
+pub fn invalid_constraint_column_test() {
+  let s =
+    schema.new("users")
+    |> schema.field(field.integer("id"))
+    |> schema.unique_constraint("bad_constraint", ["nonexistent"])
+
+  schema.is_valid(s) |> should.be_false
+  let errors = schema.validate(s)
+  list.contains(
+    errors,
+    InvalidConstraintColumn("bad_constraint", "nonexistent"),
+  )
+  |> should.be_true
+}
+
+// ============================================================================
+// SCHEMA DIFF TESTS
+// ============================================================================
+
+pub fn diff_no_changes_test() {
+  let s1 =
+    schema.new("users")
+    |> schema.field(field.integer("id"))
+    |> schema.field(field.string("email"))
+
+  let s2 =
+    schema.new("users")
+    |> schema.field(field.integer("id"))
+    |> schema.field(field.string("email"))
+
+  schema.diff(s1, s2) |> should.equal([])
+}
+
+pub fn diff_field_added_test() {
+  let old_schema =
+    schema.new("users")
+    |> schema.field(field.integer("id"))
+
+  let new_schema =
+    schema.new("users")
+    |> schema.field(field.integer("id"))
+    |> schema.field(field.string("email"))
+
+  let diffs = schema.diff(old_schema, new_schema)
+  diffs |> list.length |> should.equal(1)
+
+  case diffs {
+    [FieldAdded(f)] -> field.get_name(f) |> should.equal("email")
+    _ -> should.fail()
+  }
+}
+
+pub fn diff_field_removed_test() {
+  let old_schema =
+    schema.new("users")
+    |> schema.field(field.integer("id"))
+    |> schema.field(field.string("email"))
+
+  let new_schema =
+    schema.new("users")
+    |> schema.field(field.integer("id"))
+
+  let diffs = schema.diff(old_schema, new_schema)
+  diffs |> list.length |> should.equal(1)
+
+  case diffs {
+    [FieldRemoved(name)] -> name |> should.equal("email")
+    _ -> should.fail()
+  }
+}
+
+pub fn diff_field_type_changed_test() {
+  let old_schema =
+    schema.new("users")
+    |> schema.field(field.integer("count"))
+
+  let new_schema =
+    schema.new("users")
+    |> schema.field(field.big_integer("count"))
+
+  let diffs = schema.diff(old_schema, new_schema)
+  diffs |> list.length |> should.equal(1)
+
+  case diffs {
+    [FieldTypeChanged(name, old_type, new_type)] -> {
+      name |> should.equal("count")
+      old_type |> should.equal(Integer)
+      new_type |> should.equal(field.BigInteger)
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn diff_primary_key_changed_test() {
+  let old_schema =
+    schema.new("users")
+    |> schema.field(field.integer("id"))
+    |> schema.single_primary_key("id")
+
+  let new_schema =
+    schema.new("users")
+    |> schema.field(field.integer("id"))
+    |> schema.field(field.integer("org_id"))
+    |> schema.primary_key(["id", "org_id"])
+
+  let diffs = schema.diff(old_schema, new_schema)
+
+  let pk_changed =
+    list.find(diffs, fn(d) {
+      case d {
+        PrimaryKeyChanged(_, _) -> True
+        _ -> False
+      }
+    })
+
+  case pk_changed {
+    Ok(PrimaryKeyChanged(old_pk, new_pk)) -> {
+      old_pk |> should.equal(["id"])
+      new_pk |> should.equal(["id", "org_id"])
+    }
+    _ -> should.fail()
+  }
+}
+
+// ============================================================================
+// MULTIPLE SCHEMAS PER DOMAIN PATTERN TEST
+// ============================================================================
+
+pub fn multiple_schemas_pattern_test() {
+  // Full schema for reads
+  let user_full =
+    schema.new("users")
+    |> schema.field(
+      field.integer("id") |> field.primary_key |> field.auto_increment,
+    )
+    |> schema.field(field.string("email") |> field.not_null |> field.unique)
+    |> schema.field(field.string("password_hash") |> field.not_null)
+    |> schema.field(field.string("name") |> field.nullable)
+    |> schema.field(
+      field.datetime("inserted_at") |> field.default_function("now()"),
+    )
+    |> schema.single_primary_key("id")
+
+  // Insert schema (no auto-generated fields)
+  let user_insert = schema.insertable_fields(user_full)
+
+  // Public schema (no sensitive fields)
+  let user_public = schema.exclude_fields(user_full, ["password_hash"])
+
+  // Verify full schema
+  schema.field_count(user_full) |> should.equal(5)
+
+  // Verify insert schema has no id (auto-increment)
+  schema.has_field(user_insert, "id") |> should.be_false
+  schema.field_count(user_insert) |> should.equal(4)
+
+  // Verify public schema has no password_hash
+  schema.has_field(user_public, "password_hash") |> should.be_false
+  schema.field_count(user_public) |> should.equal(4)
+}

--- a/test/fixtures/blog_schemas.gleam
+++ b/test/fixtures/blog_schemas.gleam
@@ -1,0 +1,379 @@
+// Blog Domain Test Fixtures
+//
+// This module provides schema definitions for a blog domain used throughout
+// cquill's test suite. These fixtures demonstrate real-world usage patterns
+// and serve as the standard example domain for all tests and documentation.
+//
+// Domain model:
+// - User: authors of posts and commenters
+// - Post: blog posts with title, body, published status
+// - Comment: comments on posts with author info
+// - Tag: categorization for posts (future)
+// - PostTag: many-to-many relationship (future)
+
+import cquill/schema.{type Schema}
+import cquill/schema/field
+import gleam/dynamic
+
+// ============================================================================
+// USER SCHEMAS
+// ============================================================================
+
+/// Full user schema with all fields
+/// Used for: reading users, admin operations
+pub fn user_schema() -> Schema {
+  schema.new("users")
+  |> schema.in_schema("public")
+  |> schema.field(
+    field.integer("id")
+    |> field.primary_key
+    |> field.auto_increment,
+  )
+  |> schema.field(
+    field.string("email")
+    |> field.not_null
+    |> field.unique
+    |> field.max_length(255),
+  )
+  |> schema.field(
+    field.string("password_hash")
+    |> field.not_null,
+  )
+  |> schema.field(
+    field.string("name")
+    |> field.nullable
+    |> field.max_length(100),
+  )
+  |> schema.field(
+    field.string("bio")
+    |> field.nullable,
+  )
+  |> schema.field(
+    field.boolean("is_admin")
+    |> field.not_null
+    |> field.default_value(dynamic.bool(False)),
+  )
+  |> schema.field(
+    field.datetime("inserted_at")
+    |> field.not_null
+    |> field.default_function("now()"),
+  )
+  |> schema.field(
+    field.datetime("updated_at")
+    |> field.not_null
+    |> field.default_function("now()"),
+  )
+  |> schema.single_primary_key("id")
+  |> schema.unique_constraint("users_email_unique", ["email"])
+  |> schema.with_comment("User accounts for the blog platform")
+}
+
+/// User schema for inserts (no auto-generated fields)
+/// Used for: creating new users
+pub fn user_insert_schema() -> Schema {
+  user_schema()
+  |> schema.insertable_fields
+  |> schema.exclude_fields(["inserted_at", "updated_at"])
+}
+
+/// Public user schema (no sensitive fields)
+/// Used for: API responses, public profiles
+pub fn user_public_schema() -> Schema {
+  user_schema()
+  |> schema.exclude_fields(["password_hash", "is_admin"])
+}
+
+/// User author schema (minimal fields for attribution)
+/// Used for: displaying post/comment authors
+pub fn user_author_schema() -> Schema {
+  user_schema()
+  |> schema.select_fields(["id", "name", "email"])
+}
+
+// ============================================================================
+// POST SCHEMAS
+// ============================================================================
+
+/// Full post schema with all fields
+/// Used for: reading posts, admin operations
+pub fn post_schema() -> Schema {
+  schema.new("posts")
+  |> schema.in_schema("public")
+  |> schema.field(
+    field.integer("id")
+    |> field.primary_key
+    |> field.auto_increment,
+  )
+  |> schema.field(
+    field.integer("user_id")
+    |> field.not_null
+    |> field.references("users", "id"),
+  )
+  |> schema.field(
+    field.string("title")
+    |> field.not_null
+    |> field.max_length(255)
+    |> field.min_length(1),
+  )
+  |> schema.field(
+    field.string("slug")
+    |> field.not_null
+    |> field.unique
+    |> field.max_length(255),
+  )
+  |> schema.field(
+    field.string("body")
+    |> field.not_null,
+  )
+  |> schema.field(
+    field.string("excerpt")
+    |> field.nullable
+    |> field.max_length(500),
+  )
+  |> schema.field(
+    field.boolean("published")
+    |> field.not_null
+    |> field.default_value(dynamic.bool(False)),
+  )
+  |> schema.field(
+    field.datetime("published_at")
+    |> field.nullable,
+  )
+  |> schema.field(
+    field.integer("view_count")
+    |> field.not_null
+    |> field.default_value(dynamic.int(0))
+    |> field.min_value(0),
+  )
+  |> schema.field(
+    field.array("tags", field.String)
+    |> field.nullable,
+  )
+  |> schema.field(
+    field.datetime("inserted_at")
+    |> field.not_null
+    |> field.default_function("now()"),
+  )
+  |> schema.field(
+    field.datetime("updated_at")
+    |> field.not_null
+    |> field.default_function("now()"),
+  )
+  |> schema.single_primary_key("id")
+  |> schema.unique_constraint("posts_slug_unique", ["slug"])
+  |> schema.index("posts_user_id_idx", ["user_id"], False)
+  |> schema.index("posts_published_at_idx", ["published_at"], False)
+  |> schema.with_comment("Blog posts")
+}
+
+/// Post schema for inserts
+/// Used for: creating new posts
+pub fn post_insert_schema() -> Schema {
+  post_schema()
+  |> schema.insertable_fields
+  |> schema.exclude_fields(["inserted_at", "updated_at", "view_count"])
+}
+
+/// Post schema for public listing (summary view)
+/// Used for: blog index, search results
+pub fn post_listing_schema() -> Schema {
+  post_schema()
+  |> schema.select_fields([
+    "id", "user_id", "title", "slug", "excerpt", "published", "published_at",
+    "view_count", "tags",
+  ])
+}
+
+/// Post schema for updates
+/// Used for: editing posts
+pub fn post_update_schema() -> Schema {
+  post_schema()
+  |> schema.select_fields([
+    "title",
+    "slug",
+    "body",
+    "excerpt",
+    "published",
+    "published_at",
+    "tags",
+  ])
+}
+
+// ============================================================================
+// COMMENT SCHEMAS
+// ============================================================================
+
+/// Full comment schema
+/// Used for: reading comments, moderation
+pub fn comment_schema() -> Schema {
+  schema.new("comments")
+  |> schema.in_schema("public")
+  |> schema.field(
+    field.integer("id")
+    |> field.primary_key
+    |> field.auto_increment,
+  )
+  |> schema.field(
+    field.integer("post_id")
+    |> field.not_null
+    |> field.references_with_action("posts", "id", field.Cascade),
+  )
+  |> schema.field(
+    field.integer("user_id")
+    |> field.nullable
+    |> field.references_with_action("users", "id", field.SetNull),
+  )
+  |> schema.field(
+    field.string("author_name")
+    |> field.not_null
+    |> field.max_length(100)
+    |> field.comment("Display name for the comment author"),
+  )
+  |> schema.field(
+    field.string("author_email")
+    |> field.nullable
+    |> field.max_length(255),
+  )
+  |> schema.field(
+    field.string("content")
+    |> field.not_null
+    |> field.min_length(1),
+  )
+  |> schema.field(
+    field.boolean("approved")
+    |> field.not_null
+    |> field.default_value(dynamic.bool(False)),
+  )
+  |> schema.field(
+    field.integer("parent_id")
+    |> field.nullable
+    |> field.references("comments", "id")
+    |> field.comment("For threaded comments - references parent comment"),
+  )
+  |> schema.field(
+    field.datetime("inserted_at")
+    |> field.not_null
+    |> field.default_function("now()"),
+  )
+  |> schema.single_primary_key("id")
+  |> schema.index("comments_post_id_idx", ["post_id"], False)
+  |> schema.index("comments_user_id_idx", ["user_id"], False)
+  |> schema.with_comment("Comments on blog posts")
+}
+
+/// Comment schema for inserts (public submission)
+/// Used for: creating new comments via public form
+pub fn comment_insert_schema() -> Schema {
+  comment_schema()
+  |> schema.select_fields([
+    "post_id",
+    "user_id",
+    "author_name",
+    "author_email",
+    "content",
+    "parent_id",
+  ])
+}
+
+/// Comment schema for public display
+/// Used for: showing comments on posts
+pub fn comment_public_schema() -> Schema {
+  comment_schema()
+  |> schema.exclude_fields(["author_email", "approved"])
+}
+
+// ============================================================================
+// TAG SCHEMAS (for future many-to-many example)
+// ============================================================================
+
+/// Tag schema
+/// Used for: categorizing posts
+pub fn tag_schema() -> Schema {
+  schema.new("tags")
+  |> schema.in_schema("public")
+  |> schema.field(
+    field.integer("id")
+    |> field.primary_key
+    |> field.auto_increment,
+  )
+  |> schema.field(
+    field.string("name")
+    |> field.not_null
+    |> field.unique
+    |> field.max_length(50),
+  )
+  |> schema.field(
+    field.string("slug")
+    |> field.not_null
+    |> field.unique
+    |> field.max_length(50),
+  )
+  |> schema.field(
+    field.string("description")
+    |> field.nullable,
+  )
+  |> schema.single_primary_key("id")
+  |> schema.with_comment("Tags for categorizing posts")
+}
+
+/// Post-Tag junction table for many-to-many
+pub fn post_tag_schema() -> Schema {
+  schema.new("post_tags")
+  |> schema.in_schema("public")
+  |> schema.field(
+    field.integer("post_id")
+    |> field.not_null
+    |> field.references_with_action("posts", "id", field.Cascade),
+  )
+  |> schema.field(
+    field.integer("tag_id")
+    |> field.not_null
+    |> field.references_with_action("tags", "id", field.Cascade),
+  )
+  |> schema.primary_key(["post_id", "tag_id"])
+  |> schema.with_comment("Junction table for post-tag relationships")
+}
+
+// ============================================================================
+// SCHEMA COLLECTIONS
+// ============================================================================
+
+/// Get all blog domain schemas
+pub fn all_schemas() -> List(Schema) {
+  [
+    user_schema(),
+    post_schema(),
+    comment_schema(),
+    tag_schema(),
+    post_tag_schema(),
+  ]
+}
+
+/// Get all full schemas (for migrations)
+pub fn full_schemas() -> List(Schema) {
+  [
+    user_schema(),
+    post_schema(),
+    comment_schema(),
+    tag_schema(),
+    post_tag_schema(),
+  ]
+}
+
+/// Get all insert schemas
+pub fn insert_schemas() -> List(Schema) {
+  [
+    user_insert_schema(),
+    post_insert_schema(),
+    comment_insert_schema(),
+  ]
+}
+
+/// Get all public schemas (for API responses)
+pub fn public_schemas() -> List(Schema) {
+  [
+    user_public_schema(),
+    post_listing_schema(),
+    comment_public_schema(),
+  ]
+}


### PR DESCRIPTION
## Summary

- Implements the Schema layer with comprehensive field metadata types
- Provides pipeline-friendly builder API for constructing schemas
- Includes blog domain test fixtures for consistent testing across cquill
- No I/O — pure types and metadata only (as per architectural principles)

Closes #13

## Changes

### Schema Types (`src/cquill/schema.gleam`)
- `Schema` type with source, fields, primary_key, table_constraints
- `TableConstraint` variants: UniqueConstraint, Index, TableCheck, CompositeForeignKey
- Support for database schema/namespace (e.g., "public" in Postgres)

### Field Types (`src/cquill/schema/field.gleam`)
- Complete `FieldType` enum covering common SQL types
- Constraint types with foreign key ON DELETE actions
- Default value support (static, function, auto-increment)

### Builder API
```gleam
let user_schema = schema.new("users")
  |> schema.in_schema("public")
  |> schema.field(field.integer("id") |> field.primary_key |> field.auto_increment)
  |> schema.field(field.string("email") |> field.not_null |> field.unique)
  |> schema.field(field.string("name") |> field.nullable)
  |> schema.single_primary_key("id")
```

### Schema Transformations
```gleam
// Create insert schema without auto-generated fields
let insert_schema = schema.insertable_fields(user_schema)

// Create public schema without sensitive fields
let public_schema = schema.exclude_fields(user_schema, ["password_hash"])
```

### Validation
```gleam
let errors = schema.validate(my_schema)
// Returns: [EmptySchema], [DuplicateField("id")], [InvalidPrimaryKey("bad")], etc.
```

## Test plan

- [x] Run `gleam test` — 100 tests passing
- [x] Verify field constructors create correct types
- [x] Verify constraint modifiers work correctly
- [x] Verify schema validation catches invalid schemas
- [x] Verify schema diff detects changes for migrations
- [x] Verify blog fixtures compile and work correctly

## Example Usage

```gleam
import cquill/schema
import cquill/schema/field

// Define a complete schema
let post_schema = schema.new("posts")
  |> schema.in_schema("public")
  |> schema.field(field.integer("id") |> field.primary_key |> field.auto_increment)
  |> schema.field(field.integer("user_id") |> field.not_null |> field.references("users", "id"))
  |> schema.field(field.string("title") |> field.not_null |> field.max_length(255))
  |> schema.field(field.string("body") |> field.not_null)
  |> schema.field(field.boolean("published") |> field.default_value(dynamic.bool(False)))
  |> schema.field(field.array("tags", field.String) |> field.nullable)
  |> schema.single_primary_key("id")
  |> schema.index("posts_user_id_idx", ["user_id"], False)

// Get field information
schema.field_names(post_schema)  // -> ["id", "user_id", "title", "body", "published", "tags"]
schema.nullable_fields(post_schema)  // -> [tags field]
schema.foreign_key_fields(post_schema)  // -> [user_id field]

// Validate
schema.is_valid(post_schema)  // -> True
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)