### PR TITLE
Implement Query AST and builder (#14)

### DIFF
--- a/src/cquill/query.gleam
+++ b/src/cquill/query.gleam
@@ -1,0 +1,853 @@
+// cquill Query Builder
+//
+// This module provides the main query builder API - a typed DSL that builds
+// abstract query structures (AST), not SQL strings.
+//
+// Queries are data: inspectable, serializable, and composable.
+//
+// Key principles:
+// - Pipeline-friendly: All functions return Query for chaining
+// - Composable: Reusable filter functions can be combined
+// - Inspectable: Queries can be examined for testing
+// - Pure: No I/O, no SQL generation
+//
+// SQL generation happens in the adapter layer, not here.
+
+import cquill/query/ast.{
+  type Condition, type Direction, type Join, type JoinType, type NullsOrder,
+  type OrderBy, type Query, type Select, type SelectExpression, type Source,
+  type Value, type Where, And, Asc, Between, BoolValue, CrossJoin, Desc, Eq,
+  FloatValue, FullJoin, Gt, Gte, In, InnerJoin, IntValue, IsNotNull, IsNull,
+  Join as JoinClause, LeftJoin, Like, ListValue, Lt, Lte, Not, NotEq, NotIn,
+  NotLike, NullValue, NullsDefault, NullsFirst, NullsLast, Or,
+  OrderBy as OrderByClause, Query as QueryRecord, Raw, RightJoin, SelectAll,
+  SelectExpr, SelectFields, StringValue, SubquerySource, TableSource,
+  Where as WhereClause,
+}
+import cquill/schema.{type Schema}
+import gleam/int
+import gleam/list
+import gleam/option.{type Option, None, Some}
+import gleam/string
+
+// ============================================================================
+// QUERY CONSTRUCTION
+// ============================================================================
+
+/// Create a new query from a schema.
+/// This is the primary entry point for building queries.
+///
+/// ## Example
+/// ```gleam
+/// let query = query.from(user_schema)
+/// ```
+pub fn from(schema: Schema) -> Query(Schema) {
+  let source = case schema.table_schema {
+    Some(schema_name) ->
+      TableSource(table: schema.source, schema_name: Some(schema_name))
+    None -> TableSource(table: schema.source, schema_name: None)
+  }
+
+  QueryRecord(
+    source:,
+    select: SelectAll,
+    wheres: [],
+    order_bys: [],
+    limit: None,
+    offset: None,
+    joins: [],
+    distinct: False,
+    group_bys: [],
+    havings: [],
+  )
+}
+
+/// Create a query from a table name directly (without schema metadata).
+/// Useful for simple queries or testing.
+pub fn from_table(table: String) -> Query(Nil) {
+  ast.new(table)
+}
+
+/// Create a query from a qualified table name (schema.table).
+pub fn from_qualified(schema_name: String, table: String) -> Query(Nil) {
+  ast.new_qualified(schema_name, table)
+}
+
+/// Create a query from a subquery.
+pub fn from_subquery(subquery: Query(a)) -> Query(Nil) {
+  let source = SubquerySource(query: coerce_query(subquery))
+  QueryRecord(
+    source:,
+    select: SelectAll,
+    wheres: [],
+    order_bys: [],
+    limit: None,
+    offset: None,
+    joins: [],
+    distinct: False,
+    group_bys: [],
+    havings: [],
+  )
+}
+
+// Helper to coerce query schema parameter
+fn coerce_query(query: Query(a)) -> Query(Nil) {
+  let QueryRecord(
+    source:,
+    select:,
+    wheres:,
+    order_bys:,
+    limit:,
+    offset:,
+    joins:,
+    distinct:,
+    group_bys:,
+    havings:,
+  ) = query
+  QueryRecord(
+    source:,
+    select:,
+    wheres:,
+    order_bys:,
+    limit:,
+    offset:,
+    joins:,
+    distinct:,
+    group_bys:,
+    havings:,
+  )
+}
+
+// ============================================================================
+// SELECTION
+// ============================================================================
+
+/// Select specific fields by name.
+///
+/// ## Example
+/// ```gleam
+/// user_query
+/// |> query.select(["id", "email", "name"])
+/// ```
+pub fn select(query: Query(s), fields: List(String)) -> Query(s) {
+  let QueryRecord(..) = query
+  QueryRecord(..query, select: SelectFields(fields))
+}
+
+/// Select all fields (SELECT *).
+/// This is the default behavior.
+pub fn select_all(query: Query(s)) -> Query(s) {
+  let QueryRecord(..) = query
+  QueryRecord(..query, select: SelectAll)
+}
+
+/// Select with expressions (for computed columns, aggregates).
+pub fn select_expr(
+  query: Query(s),
+  expressions: List(SelectExpression),
+) -> Query(s) {
+  let QueryRecord(..) = query
+  QueryRecord(..query, select: SelectExpr(expressions))
+}
+
+/// Add DISTINCT to the query.
+pub fn distinct(query: Query(s)) -> Query(s) {
+  let QueryRecord(..) = query
+  QueryRecord(..query, distinct: True)
+}
+
+// ============================================================================
+// WHERE CONDITIONS
+// ============================================================================
+
+/// Add a WHERE condition to the query.
+/// Multiple where clauses are combined with AND.
+///
+/// ## Example
+/// ```gleam
+/// user_query
+/// |> query.where(query.eq("active", True))
+/// |> query.where(query.gt("age", 18))
+/// ```
+pub fn where(query: Query(s), condition: Condition) -> Query(s) {
+  let QueryRecord(wheres:, ..) = query
+  QueryRecord(..query, wheres: list.append(wheres, [WhereClause(condition)]))
+}
+
+/// Add an OR condition to the query.
+/// This wraps existing conditions and the new one in an OR.
+///
+/// ## Example
+/// ```gleam
+/// user_query
+/// |> query.where(query.eq("role", "admin"))
+/// |> query.or_where(query.eq("role", "moderator"))
+/// ```
+pub fn or_where(query: Query(s), condition: Condition) -> Query(s) {
+  let QueryRecord(wheres:, ..) = query
+  case wheres {
+    [] -> QueryRecord(..query, wheres: [WhereClause(condition)])
+    existing -> {
+      let existing_conditions = list.map(existing, fn(w) { w.condition })
+      let combined = Or([And(existing_conditions), condition])
+      QueryRecord(..query, wheres: [WhereClause(combined)])
+    }
+  }
+}
+
+/// Replace all WHERE conditions with the given condition.
+pub fn where_replace(query: Query(s), condition: Condition) -> Query(s) {
+  let QueryRecord(..) = query
+  QueryRecord(..query, wheres: [WhereClause(condition)])
+}
+
+/// Clear all WHERE conditions.
+pub fn where_clear(query: Query(s)) -> Query(s) {
+  let QueryRecord(..) = query
+  QueryRecord(..query, wheres: [])
+}
+
+// ============================================================================
+// CONDITION BUILDERS
+// ============================================================================
+
+/// Create an equality condition: field = value
+pub fn eq(field: String, value: a) -> Condition {
+  Eq(field:, value: to_value(value))
+}
+
+/// Create a not-equal condition: field != value
+pub fn not_eq(field: String, value: a) -> Condition {
+  NotEq(field:, value: to_value(value))
+}
+
+/// Create a greater-than condition: field > value
+pub fn gt(field: String, value: a) -> Condition {
+  Gt(field:, value: to_value(value))
+}
+
+/// Create a greater-than-or-equal condition: field >= value
+pub fn gte(field: String, value: a) -> Condition {
+  Gte(field:, value: to_value(value))
+}
+
+/// Create a less-than condition: field < value
+pub fn lt(field: String, value: a) -> Condition {
+  Lt(field:, value: to_value(value))
+}
+
+/// Create a less-than-or-equal condition: field <= value
+pub fn lte(field: String, value: a) -> Condition {
+  Lte(field:, value: to_value(value))
+}
+
+/// Create an IN condition: field IN (values...)
+pub fn is_in(field: String, values: List(a)) -> Condition {
+  In(field:, values: list.map(values, to_value))
+}
+
+/// Create a NOT IN condition: field NOT IN (values...)
+pub fn is_not_in(field: String, values: List(a)) -> Condition {
+  NotIn(field:, values: list.map(values, to_value))
+}
+
+/// Create a LIKE condition: field LIKE pattern
+pub fn like(field: String, pattern: String) -> Condition {
+  Like(field:, pattern:)
+}
+
+/// Create a NOT LIKE condition: field NOT LIKE pattern
+pub fn not_like(field: String, pattern: String) -> Condition {
+  NotLike(field:, pattern:)
+}
+
+/// Create an IS NULL condition
+pub fn is_null(field: String) -> Condition {
+  IsNull(field)
+}
+
+/// Create an IS NOT NULL condition
+pub fn is_not_null(field: String) -> Condition {
+  IsNotNull(field)
+}
+
+/// Create a BETWEEN condition: field BETWEEN low AND high
+pub fn between(field: String, low: a, high: a) -> Condition {
+  Between(field:, low: to_value(low), high: to_value(high))
+}
+
+/// Combine conditions with AND
+pub fn and(conditions: List(Condition)) -> Condition {
+  And(conditions)
+}
+
+/// Combine conditions with OR
+pub fn or(conditions: List(Condition)) -> Condition {
+  Or(conditions)
+}
+
+/// Negate a condition
+pub fn not(condition: Condition) -> Condition {
+  Not(condition)
+}
+
+// ============================================================================
+// VALUE CONVERSION
+// ============================================================================
+
+/// Convert a Gleam value to a query Value.
+/// Uses dynamic dispatch to determine the type.
+fn to_value(value: a) -> Value {
+  // This uses Gleam's type inference to create the appropriate value
+  // The compiler will optimize this based on the actual type
+  case coerce_to_dynamic(value) {
+    IntVal(i) -> IntValue(i)
+    FloatVal(f) -> FloatValue(f)
+    StringVal(s) -> StringValue(s)
+    BoolVal(b) -> BoolValue(b)
+    NilVal -> NullValue
+    ListVal(vals) -> ListValue(list.map(vals, fn(v) { to_value_from_dyn(v) }))
+    UnknownVal -> StringValue("")
+  }
+}
+
+// Internal type for dynamic value handling
+type DynValue {
+  IntVal(Int)
+  FloatVal(Float)
+  StringVal(String)
+  BoolVal(Bool)
+  NilVal
+  ListVal(List(DynValue))
+  UnknownVal
+}
+
+@external(erlang, "cquill_ffi", "coerce_value")
+@external(javascript, "../cquill_ffi.mjs", "coerce_value")
+fn coerce_to_dynamic(value: a) -> DynValue
+
+fn to_value_from_dyn(dyn: DynValue) -> Value {
+  case dyn {
+    IntVal(i) -> IntValue(i)
+    FloatVal(f) -> FloatValue(f)
+    StringVal(s) -> StringValue(s)
+    BoolVal(b) -> BoolValue(b)
+    NilVal -> NullValue
+    ListVal(vals) -> ListValue(list.map(vals, to_value_from_dyn))
+    UnknownVal -> StringValue("")
+  }
+}
+
+// Type-safe value constructors for explicit use
+/// Create an integer value
+pub fn int_value(value: Int) -> Value {
+  IntValue(value)
+}
+
+/// Create a float value
+pub fn float_value(value: Float) -> Value {
+  FloatValue(value)
+}
+
+/// Create a string value
+pub fn string_value(value: String) -> Value {
+  StringValue(value)
+}
+
+/// Create a boolean value
+pub fn bool_value(value: Bool) -> Value {
+  BoolValue(value)
+}
+
+/// Create a null value
+pub fn null_value() -> Value {
+  NullValue
+}
+
+/// Create a list value
+pub fn list_value(values: List(Value)) -> Value {
+  ListValue(values)
+}
+
+// Type-safe condition constructors using explicit Value types
+/// Create an equality condition with explicit integer value
+pub fn eq_int(field: String, value: Int) -> Condition {
+  Eq(field:, value: IntValue(value))
+}
+
+/// Create an equality condition with explicit string value
+pub fn eq_string(field: String, value: String) -> Condition {
+  Eq(field:, value: StringValue(value))
+}
+
+/// Create an equality condition with explicit boolean value
+pub fn eq_bool(field: String, value: Bool) -> Condition {
+  Eq(field:, value: BoolValue(value))
+}
+
+/// Create a greater-than condition with explicit integer value
+pub fn gt_int(field: String, value: Int) -> Condition {
+  Gt(field:, value: IntValue(value))
+}
+
+/// Create a less-than condition with explicit integer value
+pub fn lt_int(field: String, value: Int) -> Condition {
+  Lt(field:, value: IntValue(value))
+}
+
+/// Create a greater-than-or-equal condition with explicit integer value
+pub fn gte_int(field: String, value: Int) -> Condition {
+  Gte(field:, value: IntValue(value))
+}
+
+/// Create a less-than-or-equal condition with explicit integer value
+pub fn lte_int(field: String, value: Int) -> Condition {
+  Lte(field:, value: IntValue(value))
+}
+
+/// Create an IN condition with explicit integer values
+pub fn in_ints(field: String, values: List(Int)) -> Condition {
+  In(field:, values: list.map(values, IntValue))
+}
+
+/// Create an IN condition with explicit string values
+pub fn in_strings(field: String, values: List(String)) -> Condition {
+  In(field:, values: list.map(values, StringValue))
+}
+
+// ============================================================================
+// ORDER BY
+// ============================================================================
+
+/// Add an ORDER BY clause to the query.
+///
+/// ## Example
+/// ```gleam
+/// user_query
+/// |> query.order_by("created_at", ast.Desc)
+/// ```
+pub fn order_by(
+  query: Query(s),
+  field: String,
+  direction: Direction,
+) -> Query(s) {
+  let QueryRecord(order_bys:, ..) = query
+  let new_order = OrderByClause(field:, direction:, nulls: NullsDefault)
+  QueryRecord(..query, order_bys: list.append(order_bys, [new_order]))
+}
+
+/// Add an ORDER BY ASC clause.
+pub fn order_by_asc(query: Query(s), field: String) -> Query(s) {
+  order_by(query, field, Asc)
+}
+
+/// Add an ORDER BY DESC clause.
+pub fn order_by_desc(query: Query(s), field: String) -> Query(s) {
+  order_by(query, field, Desc)
+}
+
+/// Add an ORDER BY clause with null ordering.
+pub fn order_by_with_nulls(
+  query: Query(s),
+  field: String,
+  direction: Direction,
+  nulls: NullsOrder,
+) -> Query(s) {
+  let QueryRecord(order_bys:, ..) = query
+  let new_order = OrderByClause(field:, direction:, nulls:)
+  QueryRecord(..query, order_bys: list.append(order_bys, [new_order]))
+}
+
+/// Clear all ORDER BY clauses.
+pub fn order_by_clear(query: Query(s)) -> Query(s) {
+  let QueryRecord(..) = query
+  QueryRecord(..query, order_bys: [])
+}
+
+// ============================================================================
+// PAGINATION
+// ============================================================================
+
+/// Set the LIMIT for the query.
+///
+/// ## Example
+/// ```gleam
+/// user_query
+/// |> query.limit(10)
+/// ```
+pub fn limit(query: Query(s), count: Int) -> Query(s) {
+  let QueryRecord(..) = query
+  QueryRecord(..query, limit: Some(count))
+}
+
+/// Set the OFFSET for the query.
+///
+/// ## Example
+/// ```gleam
+/// user_query
+/// |> query.offset(20)
+/// |> query.limit(10)
+/// ```
+pub fn offset(query: Query(s), count: Int) -> Query(s) {
+  let QueryRecord(..) = query
+  QueryRecord(..query, offset: Some(count))
+}
+
+/// Set both LIMIT and OFFSET for pagination.
+///
+/// ## Example
+/// ```gleam
+/// // Page 3 with 10 items per page
+/// user_query
+/// |> query.paginate(page: 3, per_page: 10)
+/// ```
+pub fn paginate(
+  query: Query(s),
+  page page: Int,
+  per_page per_page: Int,
+) -> Query(s) {
+  let offset_val = { page - 1 } * per_page
+  query
+  |> limit(per_page)
+  |> offset(offset_val)
+}
+
+/// Remove LIMIT and OFFSET.
+pub fn no_pagination(query: Query(s)) -> Query(s) {
+  let QueryRecord(..) = query
+  QueryRecord(..query, limit: None, offset: None)
+}
+
+// ============================================================================
+// JOINS
+// ============================================================================
+
+/// Add an INNER JOIN to the query.
+pub fn join(query: Query(s), table: String, on on: Condition) -> Query(s) {
+  add_join(query, InnerJoin, table, None, on)
+}
+
+/// Add an INNER JOIN with an alias.
+pub fn join_as(
+  query: Query(s),
+  table: String,
+  alias alias: String,
+  on on: Condition,
+) -> Query(s) {
+  add_join(query, InnerJoin, table, Some(alias), on)
+}
+
+/// Add a LEFT JOIN to the query.
+pub fn left_join(query: Query(s), table: String, on on: Condition) -> Query(s) {
+  add_join(query, LeftJoin, table, None, on)
+}
+
+/// Add a LEFT JOIN with an alias.
+pub fn left_join_as(
+  query: Query(s),
+  table: String,
+  alias alias: String,
+  on on: Condition,
+) -> Query(s) {
+  add_join(query, LeftJoin, table, Some(alias), on)
+}
+
+/// Add a RIGHT JOIN to the query.
+pub fn right_join(query: Query(s), table: String, on on: Condition) -> Query(s) {
+  add_join(query, RightJoin, table, None, on)
+}
+
+/// Add a FULL OUTER JOIN to the query.
+pub fn full_join(query: Query(s), table: String, on on: Condition) -> Query(s) {
+  add_join(query, FullJoin, table, None, on)
+}
+
+/// Add a CROSS JOIN to the query.
+pub fn cross_join(query: Query(s), table: String) -> Query(s) {
+  // Cross join doesn't need an ON condition, use a dummy True condition
+  add_join(query, CrossJoin, table, None, Eq("1", IntValue(1)))
+}
+
+fn add_join(
+  query: Query(s),
+  join_type: JoinType,
+  table: String,
+  table_alias: Option(String),
+  on: Condition,
+) -> Query(s) {
+  let QueryRecord(joins:, ..) = query
+  let new_join = JoinClause(join_type:, table:, table_alias:, on:)
+  QueryRecord(..query, joins: list.append(joins, [new_join]))
+}
+
+// ============================================================================
+// GROUP BY / HAVING
+// ============================================================================
+
+/// Add a GROUP BY field.
+pub fn group_by(query: Query(s), field: String) -> Query(s) {
+  let QueryRecord(group_bys:, ..) = query
+  QueryRecord(..query, group_bys: list.append(group_bys, [field]))
+}
+
+/// Add multiple GROUP BY fields.
+pub fn group_by_fields(query: Query(s), fields: List(String)) -> Query(s) {
+  let QueryRecord(group_bys:, ..) = query
+  QueryRecord(..query, group_bys: list.append(group_bys, fields))
+}
+
+/// Add a HAVING condition.
+pub fn having(query: Query(s), condition: Condition) -> Query(s) {
+  let QueryRecord(havings:, ..) = query
+  QueryRecord(..query, havings: list.append(havings, [WhereClause(condition)]))
+}
+
+// ============================================================================
+// QUERY INSPECTION
+// ============================================================================
+
+/// Get all WHERE conditions from the query.
+pub fn get_conditions(query: Query(s)) -> List(Condition) {
+  let QueryRecord(wheres:, ..) = query
+  list.map(wheres, fn(w) { w.condition })
+}
+
+/// Get all ORDER BY clauses from the query.
+pub fn get_order_bys(query: Query(s)) -> List(OrderBy) {
+  let QueryRecord(order_bys:, ..) = query
+  order_bys
+}
+
+/// Get the SELECT clause.
+pub fn get_select(query: Query(s)) -> Select {
+  let QueryRecord(select:, ..) = query
+  select
+}
+
+/// Get the LIMIT value.
+pub fn get_limit(query: Query(s)) -> Option(Int) {
+  let QueryRecord(limit:, ..) = query
+  limit
+}
+
+/// Get the OFFSET value.
+pub fn get_offset(query: Query(s)) -> Option(Int) {
+  let QueryRecord(offset:, ..) = query
+  offset
+}
+
+/// Get all JOIN clauses.
+pub fn get_joins(query: Query(s)) -> List(Join) {
+  let QueryRecord(joins:, ..) = query
+  joins
+}
+
+/// Get the source of the query.
+pub fn get_source(query: Query(s)) -> Source {
+  let QueryRecord(source:, ..) = query
+  source
+}
+
+/// Check if the query has any WHERE conditions.
+pub fn has_conditions(query: Query(s)) -> Bool {
+  let QueryRecord(wheres:, ..) = query
+  !list.is_empty(wheres)
+}
+
+/// Check if the query has any ORDER BY clauses.
+pub fn has_order_by(query: Query(s)) -> Bool {
+  let QueryRecord(order_bys:, ..) = query
+  !list.is_empty(order_bys)
+}
+
+/// Check if the query has pagination.
+pub fn has_pagination(query: Query(s)) -> Bool {
+  let QueryRecord(limit:, offset:, ..) = query
+  option.is_some(limit) || option.is_some(offset)
+}
+
+/// Check if the query is DISTINCT.
+pub fn is_distinct(query: Query(s)) -> Bool {
+  let QueryRecord(distinct:, ..) = query
+  distinct
+}
+
+/// Count the number of WHERE conditions.
+pub fn condition_count(query: Query(s)) -> Int {
+  let QueryRecord(wheres:, ..) = query
+  list.length(wheres)
+}
+
+// ============================================================================
+// DEBUG / STRING REPRESENTATION
+// ============================================================================
+
+/// Convert a query to a debug string representation.
+/// This is for debugging and testing, NOT for SQL generation.
+pub fn to_debug_string(query: Query(s)) -> String {
+  let QueryRecord(
+    source:,
+    select:,
+    wheres:,
+    order_bys:,
+    limit:,
+    offset:,
+    joins:,
+    distinct:,
+    group_bys:,
+    havings:,
+  ) = query
+
+  let parts = [
+    "Query {",
+    "  source: " <> source_to_string(source),
+    "  select: " <> select_to_string(select),
+    "  distinct: " <> bool_to_string(distinct),
+    "  wheres: [" <> string.join(list.map(wheres, where_to_string), ", ") <> "]",
+    "  joins: [" <> string.join(list.map(joins, join_to_string), ", ") <> "]",
+    "  group_bys: [" <> string.join(group_bys, ", ") <> "]",
+    "  havings: ["
+      <> string.join(list.map(havings, where_to_string), ", ")
+      <> "]",
+    "  order_bys: ["
+      <> string.join(list.map(order_bys, order_by_to_string), ", ")
+      <> "]",
+    "  limit: " <> option_int_to_string(limit),
+    "  offset: " <> option_int_to_string(offset),
+    "}",
+  ]
+
+  string.join(parts, "\n")
+}
+
+fn source_to_string(source: Source) -> String {
+  case source {
+    TableSource(table, None) -> table
+    TableSource(table, Some(schema)) -> schema <> "." <> table
+    SubquerySource(_) -> "(subquery)"
+  }
+}
+
+fn select_to_string(select: Select) -> String {
+  case select {
+    SelectAll -> "*"
+    SelectFields(fields) -> string.join(fields, ", ")
+    SelectExpr(_) -> "(expressions)"
+  }
+}
+
+fn where_to_string(w: Where) -> String {
+  condition_to_string(w.condition)
+}
+
+fn condition_to_string(cond: Condition) -> String {
+  case cond {
+    Eq(field, value) -> field <> " = " <> value_to_string(value)
+    NotEq(field, value) -> field <> " != " <> value_to_string(value)
+    Gt(field, value) -> field <> " > " <> value_to_string(value)
+    Gte(field, value) -> field <> " >= " <> value_to_string(value)
+    Lt(field, value) -> field <> " < " <> value_to_string(value)
+    Lte(field, value) -> field <> " <= " <> value_to_string(value)
+    In(field, values) ->
+      field
+      <> " IN ("
+      <> string.join(list.map(values, value_to_string), ", ")
+      <> ")"
+    NotIn(field, values) ->
+      field
+      <> " NOT IN ("
+      <> string.join(list.map(values, value_to_string), ", ")
+      <> ")"
+    Like(field, pattern) -> field <> " LIKE '" <> pattern <> "'"
+    NotLike(field, pattern) -> field <> " NOT LIKE '" <> pattern <> "'"
+    IsNull(field) -> field <> " IS NULL"
+    IsNotNull(field) -> field <> " IS NOT NULL"
+    Between(field, low, high) ->
+      field
+      <> " BETWEEN "
+      <> value_to_string(low)
+      <> " AND "
+      <> value_to_string(high)
+    And(conditions) ->
+      "("
+      <> string.join(list.map(conditions, condition_to_string), " AND ")
+      <> ")"
+    Or(conditions) ->
+      "("
+      <> string.join(list.map(conditions, condition_to_string), " OR ")
+      <> ")"
+    Not(condition) -> "NOT (" <> condition_to_string(condition) <> ")"
+    Raw(sql, _) -> "RAW: " <> sql
+  }
+}
+
+fn value_to_string(value: Value) -> String {
+  case value {
+    IntValue(i) -> int.to_string(i)
+    FloatValue(f) -> string.inspect(f)
+    StringValue(s) -> "'" <> s <> "'"
+    BoolValue(b) -> bool_to_string(b)
+    NullValue -> "NULL"
+    ast.ParamValue(p) -> "$" <> int.to_string(p)
+    ListValue(values) ->
+      "[" <> string.join(list.map(values, value_to_string), ", ") <> "]"
+  }
+}
+
+fn order_by_to_string(ob: OrderBy) -> String {
+  let dir = case ob.direction {
+    Asc -> "ASC"
+    Desc -> "DESC"
+  }
+  let nulls = case ob.nulls {
+    NullsDefault -> ""
+    NullsFirst -> " NULLS FIRST"
+    NullsLast -> " NULLS LAST"
+  }
+  ob.field <> " " <> dir <> nulls
+}
+
+fn join_to_string(j: Join) -> String {
+  let join_type = case j.join_type {
+    InnerJoin -> "INNER JOIN"
+    LeftJoin -> "LEFT JOIN"
+    RightJoin -> "RIGHT JOIN"
+    FullJoin -> "FULL JOIN"
+    CrossJoin -> "CROSS JOIN"
+  }
+  let table = case j.table_alias {
+    Some(alias) -> j.table <> " AS " <> alias
+    None -> j.table
+  }
+  join_type <> " " <> table <> " ON " <> condition_to_string(j.on)
+}
+
+fn bool_to_string(b: Bool) -> String {
+  case b {
+    True -> "true"
+    False -> "false"
+  }
+}
+
+fn option_int_to_string(opt: Option(Int)) -> String {
+  case opt {
+    Some(i) -> int.to_string(i)
+    None -> "None"
+  }
+}
+
+// ============================================================================
+// RE-EXPORTS FROM AST
+// ============================================================================
+
+// Re-export direction types for convenience
+pub const asc = Asc
+
+pub const desc = Desc
+
+// Re-export nulls order types
+pub const nulls_first = NullsFirst
+
+pub const nulls_last = NullsLast
+
+pub const nulls_default = NullsDefault

--- a/src/cquill/query/ast.gleam
+++ b/src/cquill/query/ast.gleam
@@ -1,0 +1,286 @@
+// cquill Query AST
+//
+// This module defines the abstract syntax tree (AST) types for queries.
+// Queries are represented as data structures, not SQL strings.
+// This enables:
+// - Inspection and debugging
+// - Composition and transformation
+// - Type-safe query building
+// - Adapter-agnostic query representation
+//
+// SQL generation happens in a separate compiler module, not here.
+
+import gleam/option.{type Option}
+
+// ============================================================================
+// CORE QUERY TYPE
+// ============================================================================
+
+/// The main query type representing a complete query AST.
+/// The schema parameter provides type safety by tracking which schema
+/// the query is built against.
+pub type Query(schema) {
+  Query(
+    /// The source table/schema being queried
+    source: Source,
+    /// What fields to select
+    select: Select,
+    /// WHERE conditions (all must match - implicit AND)
+    wheres: List(Where),
+    /// ORDER BY clauses
+    order_bys: List(OrderBy),
+    /// LIMIT clause
+    limit: Option(Int),
+    /// OFFSET clause
+    offset: Option(Int),
+    /// JOIN clauses
+    joins: List(Join),
+    /// DISTINCT flag
+    distinct: Bool,
+    /// GROUP BY fields
+    group_bys: List(String),
+    /// HAVING conditions (for aggregate queries)
+    havings: List(Where),
+  )
+}
+
+// ============================================================================
+// SOURCE TYPES
+// ============================================================================
+
+/// Represents the source of a query (table, subquery, etc.)
+pub type Source {
+  /// Query from a table by name
+  TableSource(table: String, schema_name: Option(String))
+  /// Query from a subquery (for future use)
+  SubquerySource(query: Query(Nil))
+}
+
+// ============================================================================
+// SELECT TYPES
+// ============================================================================
+
+/// What columns to select
+pub type Select {
+  /// SELECT * - all columns
+  SelectAll
+  /// SELECT specific fields by name
+  SelectFields(List(String))
+  /// SELECT expressions (for computed columns, aggregates)
+  SelectExpr(List(SelectExpression))
+}
+
+/// A select expression with optional alias
+pub type SelectExpression {
+  SelectExpression(expr: Expr, alias: Option(String))
+}
+
+/// Expression types for SELECT clauses
+pub type Expr {
+  /// A column reference
+  ColumnExpr(field: String)
+  /// A qualified column (table.field)
+  QualifiedColumnExpr(table: String, field: String)
+  /// A literal value
+  LiteralExpr(value: Value)
+  /// An aggregate function
+  AggregateExpr(func: AggregateFunc, field: String)
+  /// A function call
+  FunctionExpr(name: String, args: List(Expr))
+  /// Binary operation
+  BinaryExpr(left: Expr, op: BinaryOp, right: Expr)
+}
+
+/// Aggregate functions
+pub type AggregateFunc {
+  Count
+  Sum
+  Avg
+  Min
+  Max
+  CountDistinct
+}
+
+/// Binary operators for expressions
+pub type BinaryOp {
+  Add
+  Subtract
+  Multiply
+  Divide
+  Concat
+}
+
+// ============================================================================
+// WHERE/CONDITION TYPES
+// ============================================================================
+
+/// A WHERE clause wrapper
+pub type Where {
+  Where(condition: Condition)
+}
+
+/// Condition types for WHERE and HAVING clauses
+pub type Condition {
+  /// field = value
+  Eq(field: String, value: Value)
+  /// field != value
+  NotEq(field: String, value: Value)
+  /// field > value
+  Gt(field: String, value: Value)
+  /// field >= value
+  Gte(field: String, value: Value)
+  /// field < value
+  Lt(field: String, value: Value)
+  /// field <= value
+  Lte(field: String, value: Value)
+  /// field IN (values...)
+  In(field: String, values: List(Value))
+  /// field NOT IN (values...)
+  NotIn(field: String, values: List(Value))
+  /// field LIKE pattern
+  Like(field: String, pattern: String)
+  /// field NOT LIKE pattern
+  NotLike(field: String, pattern: String)
+  /// field IS NULL
+  IsNull(field: String)
+  /// field IS NOT NULL
+  IsNotNull(field: String)
+  /// field BETWEEN low AND high
+  Between(field: String, low: Value, high: Value)
+  /// Combined conditions (all must be true)
+  And(List(Condition))
+  /// Alternative conditions (any can be true)
+  Or(List(Condition))
+  /// Negated condition
+  Not(Condition)
+  /// Raw condition for advanced use cases
+  Raw(sql: String, params: List(Value))
+}
+
+// ============================================================================
+// VALUE TYPES
+// ============================================================================
+
+/// Represents a value in a query (for parameters, literals)
+pub type Value {
+  /// Integer value
+  IntValue(Int)
+  /// Float value
+  FloatValue(Float)
+  /// String value
+  StringValue(String)
+  /// Boolean value
+  BoolValue(Bool)
+  /// NULL value
+  NullValue
+  /// Positional parameter placeholder ($1, $2, etc.)
+  ParamValue(position: Int)
+  /// List of values (for IN clauses)
+  ListValue(List(Value))
+}
+
+// ============================================================================
+// ORDER BY TYPES
+// ============================================================================
+
+/// ORDER BY clause
+pub type OrderBy {
+  OrderBy(field: String, direction: Direction, nulls: NullsOrder)
+}
+
+/// Sort direction
+pub type Direction {
+  Asc
+  Desc
+}
+
+/// NULL ordering preference
+pub type NullsOrder {
+  /// Use database default
+  NullsDefault
+  /// NULLs come first
+  NullsFirst
+  /// NULLs come last
+  NullsLast
+}
+
+// ============================================================================
+// JOIN TYPES
+// ============================================================================
+
+/// JOIN clause
+pub type Join {
+  Join(
+    join_type: JoinType,
+    table: String,
+    table_alias: Option(String),
+    on: Condition,
+  )
+}
+
+/// Types of JOIN
+pub type JoinType {
+  InnerJoin
+  LeftJoin
+  RightJoin
+  FullJoin
+  CrossJoin
+}
+
+// ============================================================================
+// QUERY OPERATIONS ENUM (for mutation tracking)
+// ============================================================================
+
+/// Type of query operation (useful for adapter routing)
+pub type QueryOperation {
+  SelectOp
+  InsertOp
+  UpdateOp
+  DeleteOp
+}
+
+// ============================================================================
+// DEFAULT CONSTRUCTORS
+// ============================================================================
+
+/// Create a new empty Query AST for a table source
+pub fn new(table: String) -> Query(Nil) {
+  Query(
+    source: TableSource(table:, schema_name: option.None),
+    select: SelectAll,
+    wheres: [],
+    order_bys: [],
+    limit: option.None,
+    offset: option.None,
+    joins: [],
+    distinct: False,
+    group_bys: [],
+    havings: [],
+  )
+}
+
+/// Create a new empty Query AST with schema qualification
+pub fn new_qualified(schema_name: String, table: String) -> Query(Nil) {
+  Query(
+    source: TableSource(table:, schema_name: option.Some(schema_name)),
+    select: SelectAll,
+    wheres: [],
+    order_bys: [],
+    limit: option.None,
+    offset: option.None,
+    joins: [],
+    distinct: False,
+    group_bys: [],
+    havings: [],
+  )
+}
+
+/// Create a default OrderBy with ascending order
+pub fn order_by_asc(field: String) -> OrderBy {
+  OrderBy(field:, direction: Asc, nulls: NullsDefault)
+}
+
+/// Create a default OrderBy with descending order
+pub fn order_by_desc(field: String) -> OrderBy {
+  OrderBy(field:, direction: Desc, nulls: NullsDefault)
+}

--- a/src/cquill/query/builder.gleam
+++ b/src/cquill/query/builder.gleam
@@ -1,0 +1,376 @@
+// cquill Query Builder Composition
+//
+// This module provides advanced composition functions for building
+// complex queries from reusable parts.
+//
+// The core philosophy is that query fragments should be:
+// - First-class values that can be passed around
+// - Composable via standard function composition
+// - Reusable across different queries
+//
+// Example usage:
+// ```gleam
+// // Define reusable filters
+// let active = builder.filter(query.eq_bool("active", True))
+// let recent = builder.filter(query.gt_int("created_at", cutoff))
+// let admin = builder.filter(query.eq_string("role", "admin"))
+//
+// // Compose them
+// let active_recent_admins = builder.compose([active, recent, admin])
+//
+// // Apply to any query
+// user_query |> active_recent_admins
+// ```
+
+import cquill/query
+import cquill/query/ast.{
+  type Condition, type Direction, type Join, type JoinType, type OrderBy,
+  type Query, type Select, Asc, Desc, InnerJoin, Join as JoinClause,
+  NullsDefault, OrderBy as OrderByClause, Query as QueryRecord, Raw, SelectAll,
+  SelectFields,
+}
+import gleam/list
+import gleam/option.{type Option, None, Some}
+
+// ============================================================================
+// QUERY MODIFIER TYPE
+// ============================================================================
+
+/// A QueryModifier is a function that transforms a query.
+/// This is the foundation for composable query building.
+pub type QueryModifier(s) =
+  fn(Query(s)) -> Query(s)
+
+// ============================================================================
+// FILTER BUILDERS
+// ============================================================================
+
+/// Create a filter modifier from a condition.
+/// Returns a function that adds the condition to any query.
+///
+/// ## Example
+/// ```gleam
+/// let active_filter = builder.filter(query.eq_bool("active", True))
+/// user_query |> active_filter
+/// ```
+pub fn filter(condition: Condition) -> QueryModifier(s) {
+  fn(q: Query(s)) { query.where(q, condition) }
+}
+
+/// Create a filter that requires a field to equal a specific integer.
+pub fn filter_eq_int(field: String, value: Int) -> QueryModifier(s) {
+  filter(query.eq_int(field, value))
+}
+
+/// Create a filter that requires a field to equal a specific string.
+pub fn filter_eq_string(field: String, value: String) -> QueryModifier(s) {
+  filter(query.eq_string(field, value))
+}
+
+/// Create a filter that requires a field to equal a specific boolean.
+pub fn filter_eq_bool(field: String, value: Bool) -> QueryModifier(s) {
+  filter(query.eq_bool(field, value))
+}
+
+/// Create a filter for non-null values.
+pub fn filter_not_null(field: String) -> QueryModifier(s) {
+  filter(query.is_not_null(field))
+}
+
+/// Create a filter for null values.
+pub fn filter_null(field: String) -> QueryModifier(s) {
+  filter(query.is_null(field))
+}
+
+/// Create a filter for values greater than a threshold.
+pub fn filter_gt_int(field: String, value: Int) -> QueryModifier(s) {
+  filter(query.gt_int(field, value))
+}
+
+// ============================================================================
+// MODIFIER COMPOSITION
+// ============================================================================
+
+/// Compose multiple modifiers into a single modifier.
+/// Modifiers are applied left to right.
+///
+/// ## Example
+/// ```gleam
+/// let active_admins = builder.compose([
+///   builder.filter(query.eq_bool("active", True)),
+///   builder.filter(query.eq_string("role", "admin")),
+///   builder.with_limit(10),
+/// ])
+/// user_query |> active_admins
+/// ```
+pub fn compose(modifiers: List(QueryModifier(s))) -> QueryModifier(s) {
+  fn(query: Query(s)) {
+    list.fold(modifiers, query, fn(q, modifier) { modifier(q) })
+  }
+}
+
+/// Compose two modifiers into a single modifier.
+pub fn and_then(
+  first: QueryModifier(s),
+  second: QueryModifier(s),
+) -> QueryModifier(s) {
+  fn(query: Query(s)) { query |> first |> second }
+}
+
+/// Create an identity modifier (does nothing).
+pub fn identity() -> QueryModifier(s) {
+  fn(query: Query(s)) { query }
+}
+
+/// Conditionally apply a modifier.
+/// If the condition is true, apply the modifier; otherwise, return unchanged.
+pub fn when(condition: Bool, modifier: QueryModifier(s)) -> QueryModifier(s) {
+  case condition {
+    True -> modifier
+    False -> identity()
+  }
+}
+
+/// Apply a modifier based on an optional value.
+/// If the value is Some, apply the modifier factory with that value.
+pub fn when_some(
+  maybe_value: Option(a),
+  modifier_factory: fn(a) -> QueryModifier(s),
+) -> QueryModifier(s) {
+  case maybe_value {
+    Some(value) -> modifier_factory(value)
+    None -> identity()
+  }
+}
+
+// ============================================================================
+// COMMON MODIFIERS
+// ============================================================================
+
+/// Create a modifier that sets the limit.
+pub fn with_limit(count: Int) -> QueryModifier(s) {
+  fn(q: Query(s)) { query.limit(q, count) }
+}
+
+/// Create a modifier that sets the offset.
+pub fn with_offset(count: Int) -> QueryModifier(s) {
+  fn(q: Query(s)) { query.offset(q, count) }
+}
+
+/// Create a modifier that sets pagination.
+pub fn with_pagination(page: Int, per_page: Int) -> QueryModifier(s) {
+  fn(q: Query(s)) { query.paginate(q, page, per_page) }
+}
+
+/// Create a modifier that adds ORDER BY ASC.
+pub fn order_asc(field: String) -> QueryModifier(s) {
+  fn(q: Query(s)) { query.order_by_asc(q, field) }
+}
+
+/// Create a modifier that adds ORDER BY DESC.
+pub fn order_desc(field: String) -> QueryModifier(s) {
+  fn(q: Query(s)) { query.order_by_desc(q, field) }
+}
+
+/// Create a modifier that sets specific fields to select.
+pub fn with_select(fields: List(String)) -> QueryModifier(s) {
+  fn(q: Query(s)) { query.select(q, fields) }
+}
+
+/// Create a modifier that makes the query distinct.
+pub fn with_distinct() -> QueryModifier(s) {
+  fn(q: Query(s)) { query.distinct(q) }
+}
+
+// ============================================================================
+// SCOPES (Named, Reusable Query Fragments)
+// ============================================================================
+
+/// A Scope is a named, reusable query modifier.
+/// This is similar to Ecto's query scopes.
+pub type Scope(s) {
+  Scope(name: String, modifier: QueryModifier(s))
+}
+
+/// Create a named scope.
+pub fn scope(name: String, modifier: QueryModifier(s)) -> Scope(s) {
+  Scope(name:, modifier:)
+}
+
+/// Apply a scope to a query.
+pub fn apply_scope(query: Query(s), scope: Scope(s)) -> Query(s) {
+  scope.modifier(query)
+}
+
+/// Apply multiple scopes to a query.
+pub fn apply_scopes(query: Query(s), scopes: List(Scope(s))) -> Query(s) {
+  list.fold(scopes, query, fn(q, s) { apply_scope(q, s) })
+}
+
+// ============================================================================
+// QUERY MERGING
+// ============================================================================
+
+/// Merge conditions from source query into target query.
+/// Preserves target's source, select, and other settings.
+pub fn merge_conditions(target: Query(s), source: Query(a)) -> Query(s) {
+  let source_conditions = query.get_conditions(source)
+  list.fold(source_conditions, target, fn(q, cond) { query.where(q, cond) })
+}
+
+/// Merge order_bys from source query into target query.
+pub fn merge_order_bys(target: Query(s), source: Query(a)) -> Query(s) {
+  let QueryRecord(order_bys: target_orders, ..) = target
+  let source_orders = query.get_order_bys(source)
+  QueryRecord(..target, order_bys: list.append(target_orders, source_orders))
+}
+
+/// Merge pagination (limit/offset) from source to target.
+/// Only applies if target doesn't already have pagination.
+pub fn merge_pagination(target: Query(s), source: Query(a)) -> Query(s) {
+  let target_limit = query.get_limit(target)
+  let target_offset = query.get_offset(target)
+  let source_limit = query.get_limit(source)
+  let source_offset = query.get_offset(source)
+
+  let new_limit = case target_limit {
+    Some(_) -> target_limit
+    None -> source_limit
+  }
+
+  let new_offset = case target_offset {
+    Some(_) -> target_offset
+    None -> source_offset
+  }
+
+  QueryRecord(..target, limit: new_limit, offset: new_offset)
+}
+
+// ============================================================================
+// COMMON PATTERNS
+// ============================================================================
+
+/// Create a "soft delete" filter that excludes soft-deleted records.
+/// Assumes a `deleted_at` field that is NULL for non-deleted records.
+pub fn not_deleted() -> QueryModifier(s) {
+  filter_null("deleted_at")
+}
+
+/// Create a "published" filter for content models.
+/// Assumes a `published` boolean field.
+pub fn published() -> QueryModifier(s) {
+  filter_eq_bool("published", True)
+}
+
+/// Create an "active" filter.
+/// Assumes an `active` boolean field.
+pub fn active() -> QueryModifier(s) {
+  filter_eq_bool("active", True)
+}
+
+/// Create a "recent first" ordering modifier.
+/// Assumes a `created_at` timestamp field.
+pub fn recent_first() -> QueryModifier(s) {
+  order_desc("created_at")
+}
+
+/// Create an "oldest first" ordering modifier.
+/// Assumes a `created_at` timestamp field.
+pub fn oldest_first() -> QueryModifier(s) {
+  order_asc("created_at")
+}
+
+/// Create a modifier for "by user" filtering.
+/// Common pattern for multi-tenant queries.
+pub fn by_user(user_id: Int) -> QueryModifier(s) {
+  filter_eq_int("user_id", user_id)
+}
+
+// ============================================================================
+// QUERY CLONING / TRANSFORMATION
+// ============================================================================
+
+/// Clone a query, optionally resetting certain parts.
+pub fn clone(q: Query(s)) -> Query(s) {
+  q
+}
+
+/// Clone a query but clear all WHERE conditions.
+pub fn clone_without_conditions(q: Query(s)) -> Query(s) {
+  query.where_clear(q)
+}
+
+/// Clone a query but clear all ORDER BY.
+pub fn clone_without_order(q: Query(s)) -> Query(s) {
+  query.order_by_clear(q)
+}
+
+/// Clone a query but clear pagination.
+pub fn clone_without_pagination(q: Query(s)) -> Query(s) {
+  query.no_pagination(q)
+}
+
+// ============================================================================
+// QUERY ANALYSIS
+// ============================================================================
+
+/// Check if two queries have equivalent conditions (order-independent).
+pub fn conditions_equivalent(query_a: Query(a), query_b: Query(b)) -> Bool {
+  let conds_a = query.get_conditions(query_a)
+  let conds_b = query.get_conditions(query_b)
+
+  list.length(conds_a) == list.length(conds_b)
+  && list.all(conds_a, fn(c) { list.contains(conds_b, c) })
+  && list.all(conds_b, fn(c) { list.contains(conds_a, c) })
+}
+
+/// Count total conditions including nested AND/OR.
+pub fn count_conditions_deep(q: Query(s)) -> Int {
+  let conditions = query.get_conditions(q)
+  list.fold(conditions, 0, fn(acc, c) { acc + count_condition_nodes(c) })
+}
+
+fn count_condition_nodes(condition: Condition) -> Int {
+  case condition {
+    ast.And(conditions) ->
+      1
+      + list.fold(conditions, 0, fn(acc, c) { acc + count_condition_nodes(c) })
+    ast.Or(conditions) ->
+      1
+      + list.fold(conditions, 0, fn(acc, c) { acc + count_condition_nodes(c) })
+    ast.Not(inner) -> 1 + count_condition_nodes(inner)
+    _ -> 1
+  }
+}
+
+/// Extract all field names referenced in conditions.
+pub fn get_condition_fields(q: Query(s)) -> List(String) {
+  let conditions = query.get_conditions(q)
+  conditions
+  |> list.flat_map(extract_fields_from_condition)
+  |> list.unique
+}
+
+fn extract_fields_from_condition(condition: Condition) -> List(String) {
+  case condition {
+    ast.Eq(field, _) -> [field]
+    ast.NotEq(field, _) -> [field]
+    ast.Gt(field, _) -> [field]
+    ast.Gte(field, _) -> [field]
+    ast.Lt(field, _) -> [field]
+    ast.Lte(field, _) -> [field]
+    ast.In(field, _) -> [field]
+    ast.NotIn(field, _) -> [field]
+    ast.Like(field, _) -> [field]
+    ast.NotLike(field, _) -> [field]
+    ast.IsNull(field) -> [field]
+    ast.IsNotNull(field) -> [field]
+    ast.Between(field, _, _) -> [field]
+    ast.And(conditions) ->
+      list.flat_map(conditions, extract_fields_from_condition)
+    ast.Or(conditions) ->
+      list.flat_map(conditions, extract_fields_from_condition)
+    ast.Not(inner) -> extract_fields_from_condition(inner)
+    Raw(_, _) -> []
+  }
+}

--- a/src/cquill_ffi.erl
+++ b/src/cquill_ffi.erl
@@ -1,0 +1,23 @@
+-module(cquill_ffi).
+-export([coerce_value/1]).
+
+%% Coerce a Gleam value to a tagged union for type detection
+%% This allows the query builder to create the appropriate Value type
+coerce_value(Value) when is_integer(Value) ->
+    {int_val, Value};
+coerce_value(Value) when is_float(Value) ->
+    {float_val, Value};
+coerce_value(Value) when is_binary(Value) ->
+    {string_val, Value};
+coerce_value(true) ->
+    {bool_val, true};
+coerce_value(false) ->
+    {bool_val, false};
+coerce_value(nil) ->
+    nil_val;
+coerce_value(none) ->
+    nil_val;
+coerce_value(Value) when is_list(Value) ->
+    {list_val, [coerce_value(V) || V <- Value]};
+coerce_value(_) ->
+    unknown_val.

--- a/src/cquill_ffi.mjs
+++ b/src/cquill_ffi.mjs
@@ -1,0 +1,35 @@
+// JavaScript FFI for cquill query builder
+// Provides value coercion for the query DSL
+
+export function coerce_value(value) {
+  if (typeof value === 'number') {
+    if (Number.isInteger(value)) {
+      return { type: 'IntVal', 0: value };
+    } else {
+      return { type: 'FloatVal', 0: value };
+    }
+  }
+
+  if (typeof value === 'string') {
+    return { type: 'StringVal', 0: value };
+  }
+
+  if (typeof value === 'boolean') {
+    return { type: 'BoolVal', 0: value };
+  }
+
+  if (value === null || value === undefined) {
+    return { type: 'NilVal' };
+  }
+
+  if (Array.isArray(value)) {
+    return { type: 'ListVal', 0: value.map(coerce_value) };
+  }
+
+  // Handle Gleam's None type
+  if (value && value.type === 'None') {
+    return { type: 'NilVal' };
+  }
+
+  return { type: 'UnknownVal' };
+}

--- a/test/cquill/query/ast_test.gleam
+++ b/test/cquill/query/ast_test.gleam
@@ -1,0 +1,324 @@
+import cquill/query/ast.{
+  type Condition, type OrderBy, type Query, type Select, type Source, type Value,
+  Asc, Desc, Eq, Gt, IntValue, NullsDefault, NullsFirst, NullsLast, OrderBy,
+  Query as QueryRecord, SelectAll, SelectFields, StringValue, TableSource,
+}
+import gleam/option.{None, Some}
+import gleeunit
+import gleeunit/should
+
+pub fn main() {
+  gleeunit.main()
+}
+
+// ============================================================================
+// QUERY AST CONSTRUCTION TESTS
+// ============================================================================
+
+pub fn new_query_test() {
+  let query = ast.new("users")
+
+  case query.source {
+    TableSource(table, None) -> table |> should.equal("users")
+    _ -> should.fail()
+  }
+
+  query.select |> should.equal(SelectAll)
+  query.wheres |> should.equal([])
+  query.order_bys |> should.equal([])
+  query.limit |> should.equal(None)
+  query.offset |> should.equal(None)
+  query.joins |> should.equal([])
+  query.distinct |> should.be_false
+}
+
+pub fn new_qualified_query_test() {
+  let query = ast.new_qualified("public", "users")
+
+  case query.source {
+    TableSource(table, Some(schema)) -> {
+      table |> should.equal("users")
+      schema |> should.equal("public")
+    }
+    _ -> should.fail()
+  }
+}
+
+// ============================================================================
+// VALUE TYPES TESTS
+// ============================================================================
+
+pub fn int_value_test() {
+  let val: Value = IntValue(42)
+  case val {
+    IntValue(n) -> n |> should.equal(42)
+    _ -> should.fail()
+  }
+}
+
+pub fn string_value_test() {
+  let val: Value = StringValue("hello")
+  case val {
+    StringValue(s) -> s |> should.equal("hello")
+    _ -> should.fail()
+  }
+}
+
+pub fn value_types_are_distinct_test() {
+  // Ensure different value types are distinguishable
+  let int_val = IntValue(1)
+  let str_val = StringValue("1")
+
+  case int_val {
+    IntValue(_) -> should.be_true(True)
+    _ -> should.fail()
+  }
+
+  case str_val {
+    StringValue(_) -> should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+// ============================================================================
+// CONDITION TYPES TESTS
+// ============================================================================
+
+pub fn eq_condition_test() {
+  let cond: Condition = Eq("id", IntValue(1))
+
+  case cond {
+    Eq(field, IntValue(val)) -> {
+      field |> should.equal("id")
+      val |> should.equal(1)
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn gt_condition_test() {
+  let cond: Condition = Gt("age", IntValue(18))
+
+  case cond {
+    Gt(field, IntValue(val)) -> {
+      field |> should.equal("age")
+      val |> should.equal(18)
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn and_condition_test() {
+  let cond: Condition =
+    ast.And([Eq("active", ast.BoolValue(True)), Gt("age", IntValue(18))])
+
+  case cond {
+    ast.And(conditions) -> {
+      conditions
+      |> list.length
+      |> should.equal(2)
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn or_condition_test() {
+  let cond: Condition =
+    ast.Or([Eq("role", StringValue("admin")), Eq("role", StringValue("mod"))])
+
+  case cond {
+    ast.Or(conditions) -> {
+      conditions
+      |> list.length
+      |> should.equal(2)
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn not_condition_test() {
+  let cond: Condition = ast.Not(Eq("deleted", ast.BoolValue(True)))
+
+  case cond {
+    ast.Not(inner) -> {
+      case inner {
+        Eq(field, _) -> field |> should.equal("deleted")
+        _ -> should.fail()
+      }
+    }
+    _ -> should.fail()
+  }
+}
+
+// ============================================================================
+// ORDER BY TESTS
+// ============================================================================
+
+pub fn order_by_asc_test() {
+  let ob: OrderBy = ast.order_by_asc("name")
+
+  ob.field |> should.equal("name")
+  ob.direction |> should.equal(Asc)
+  ob.nulls |> should.equal(NullsDefault)
+}
+
+pub fn order_by_desc_test() {
+  let ob: OrderBy = ast.order_by_desc("created_at")
+
+  ob.field |> should.equal("created_at")
+  ob.direction |> should.equal(Desc)
+}
+
+pub fn order_by_with_nulls_test() {
+  let ob: OrderBy = OrderBy("score", Desc, NullsLast)
+
+  ob.field |> should.equal("score")
+  ob.direction |> should.equal(Desc)
+  ob.nulls |> should.equal(NullsLast)
+}
+
+pub fn nulls_order_types_test() {
+  // Verify all nulls order types are distinct
+  let default = NullsDefault
+  let first = NullsFirst
+  let last = NullsLast
+
+  case default {
+    NullsDefault -> should.be_true(True)
+    _ -> should.fail()
+  }
+
+  case first {
+    NullsFirst -> should.be_true(True)
+    _ -> should.fail()
+  }
+
+  case last {
+    NullsLast -> should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+// ============================================================================
+// SELECT TESTS
+// ============================================================================
+
+pub fn select_all_test() {
+  let sel: Select = SelectAll
+
+  case sel {
+    SelectAll -> should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+pub fn select_fields_test() {
+  let sel: Select = SelectFields(["id", "name", "email"])
+
+  case sel {
+    SelectFields(fields) -> {
+      fields
+      |> list.length
+      |> should.equal(3)
+      fields |> should.equal(["id", "name", "email"])
+    }
+    _ -> should.fail()
+  }
+}
+
+// ============================================================================
+// JOIN TESTS
+// ============================================================================
+
+pub fn inner_join_test() {
+  let join: ast.Join =
+    ast.Join(
+      join_type: ast.InnerJoin,
+      table: "posts",
+      table_alias: None,
+      on: Eq("users.id", ast.ParamValue(1)),
+    )
+
+  join.join_type |> should.equal(ast.InnerJoin)
+  join.table |> should.equal("posts")
+  join.table_alias |> should.equal(None)
+}
+
+pub fn left_join_with_alias_test() {
+  let join: ast.Join =
+    ast.Join(
+      join_type: ast.LeftJoin,
+      table: "comments",
+      table_alias: Some("c"),
+      on: Eq("posts.id", ast.ParamValue(1)),
+    )
+
+  join.join_type |> should.equal(ast.LeftJoin)
+  join.table |> should.equal("comments")
+  join.table_alias |> should.equal(Some("c"))
+}
+
+pub fn join_types_test() {
+  // Verify all join types are distinct
+  let inner = ast.InnerJoin
+  let left = ast.LeftJoin
+  let right = ast.RightJoin
+  let full = ast.FullJoin
+  let cross = ast.CrossJoin
+
+  case inner {
+    ast.InnerJoin -> should.be_true(True)
+    _ -> should.fail()
+  }
+
+  case left {
+    ast.LeftJoin -> should.be_true(True)
+    _ -> should.fail()
+  }
+
+  case right {
+    ast.RightJoin -> should.be_true(True)
+    _ -> should.fail()
+  }
+
+  case full {
+    ast.FullJoin -> should.be_true(True)
+    _ -> should.fail()
+  }
+
+  case cross {
+    ast.CrossJoin -> should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+// ============================================================================
+// SOURCE TESTS
+// ============================================================================
+
+pub fn table_source_test() {
+  let src: Source = TableSource("users", None)
+
+  case src {
+    TableSource(table, None) -> table |> should.equal("users")
+    _ -> should.fail()
+  }
+}
+
+pub fn qualified_table_source_test() {
+  let src: Source = TableSource("users", Some("public"))
+
+  case src {
+    TableSource(table, Some(schema)) -> {
+      table |> should.equal("users")
+      schema |> should.equal("public")
+    }
+    _ -> should.fail()
+  }
+}
+
+// ============================================================================
+// IMPORTS
+// ============================================================================
+
+import gleam/list

--- a/test/cquill/query/builder_test.gleam
+++ b/test/cquill/query/builder_test.gleam
@@ -1,0 +1,618 @@
+import cquill/query
+import cquill/query/ast.{IntValue}
+import cquill/query/builder
+import cquill/schema
+import cquill/schema/field
+import gleam/list
+import gleam/option.{None, Some}
+import gleeunit
+import gleeunit/should
+
+pub fn main() {
+  gleeunit.main()
+}
+
+// ============================================================================
+// TEST HELPERS
+// ============================================================================
+
+fn user_schema() -> schema.Schema {
+  schema.new("users")
+  |> schema.field(field.integer("id") |> field.primary_key)
+  |> schema.field(field.string("email") |> field.not_null |> field.unique)
+  |> schema.field(field.string("name") |> field.nullable)
+  |> schema.field(field.boolean("active"))
+  |> schema.field(field.integer("age"))
+  |> schema.field(field.integer("user_id") |> field.nullable)
+  |> schema.field(field.datetime("created_at"))
+  |> schema.field(field.datetime("deleted_at") |> field.nullable)
+  |> schema.primary_key(["id"])
+}
+
+// ============================================================================
+// FILTER BUILDER TESTS
+// ============================================================================
+
+pub fn filter_test() {
+  let active_filter = builder.filter(query.eq_bool("active", True))
+
+  let q =
+    query.from(user_schema())
+    |> active_filter
+
+  query.condition_count(q) |> should.equal(1)
+
+  let conditions = query.get_conditions(q)
+  case conditions {
+    [ast.Eq("active", ast.BoolValue(True))] -> should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+pub fn filter_eq_int_test() {
+  let id_filter = builder.filter_eq_int("id", 42)
+
+  let q =
+    query.from(user_schema())
+    |> id_filter
+
+  let conditions = query.get_conditions(q)
+  case conditions {
+    [ast.Eq("id", IntValue(42))] -> should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+pub fn filter_eq_string_test() {
+  let email_filter = builder.filter_eq_string("email", "test@example.com")
+
+  let q =
+    query.from(user_schema())
+    |> email_filter
+
+  let conditions = query.get_conditions(q)
+  case conditions {
+    [ast.Eq("email", ast.StringValue("test@example.com"))] ->
+      should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+pub fn filter_not_null_test() {
+  let not_null_filter = builder.filter_not_null("email")
+
+  let q =
+    query.from(user_schema())
+    |> not_null_filter
+
+  let conditions = query.get_conditions(q)
+  case conditions {
+    [ast.IsNotNull("email")] -> should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+pub fn filter_null_test() {
+  let null_filter = builder.filter_null("deleted_at")
+
+  let q =
+    query.from(user_schema())
+    |> null_filter
+
+  let conditions = query.get_conditions(q)
+  case conditions {
+    [ast.IsNull("deleted_at")] -> should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+// ============================================================================
+// MODIFIER COMPOSITION TESTS
+// ============================================================================
+
+pub fn compose_test() {
+  let active = builder.filter(query.eq_bool("active", True))
+  let adult = builder.filter(query.gt_int("age", 18))
+  let limited = builder.with_limit(10)
+
+  let composed = builder.compose([active, adult, limited])
+
+  let q =
+    query.from(user_schema())
+    |> composed
+
+  query.condition_count(q) |> should.equal(2)
+  query.get_limit(q) |> should.equal(Some(10))
+}
+
+pub fn and_then_test() {
+  let active = builder.filter(query.eq_bool("active", True))
+  let limited = builder.with_limit(5)
+
+  let combined = builder.and_then(active, limited)
+
+  let q =
+    query.from(user_schema())
+    |> combined
+
+  query.condition_count(q) |> should.equal(1)
+  query.get_limit(q) |> should.equal(Some(5))
+}
+
+pub fn identity_test() {
+  let q1 = query.from(user_schema())
+  let q2 =
+    query.from(user_schema())
+    |> builder.identity()
+
+  // Identity should not change the query
+  query.get_conditions(q1) |> should.equal(query.get_conditions(q2))
+  query.get_limit(q1) |> should.equal(query.get_limit(q2))
+}
+
+pub fn when_true_test() {
+  let should_filter = True
+  let conditional = builder.when(should_filter, builder.with_limit(10))
+
+  let q =
+    query.from(user_schema())
+    |> conditional
+
+  query.get_limit(q) |> should.equal(Some(10))
+}
+
+pub fn when_false_test() {
+  let should_filter = False
+  let conditional = builder.when(should_filter, builder.with_limit(10))
+
+  let q =
+    query.from(user_schema())
+    |> conditional
+
+  query.get_limit(q) |> should.equal(None)
+}
+
+pub fn when_some_test() {
+  let maybe_limit: option.Option(Int) = Some(25)
+  let conditional = builder.when_some(maybe_limit, builder.with_limit)
+
+  let q =
+    query.from(user_schema())
+    |> conditional
+
+  query.get_limit(q) |> should.equal(Some(25))
+}
+
+pub fn when_none_test() {
+  let maybe_limit: option.Option(Int) = None
+  let conditional = builder.when_some(maybe_limit, builder.with_limit)
+
+  let q =
+    query.from(user_schema())
+    |> conditional
+
+  query.get_limit(q) |> should.equal(None)
+}
+
+// ============================================================================
+// COMMON MODIFIER TESTS
+// ============================================================================
+
+pub fn with_limit_test() {
+  let q =
+    query.from(user_schema())
+    |> builder.with_limit(20)
+
+  query.get_limit(q) |> should.equal(Some(20))
+}
+
+pub fn with_offset_test() {
+  let q =
+    query.from(user_schema())
+    |> builder.with_offset(100)
+
+  query.get_offset(q) |> should.equal(Some(100))
+}
+
+pub fn with_pagination_test() {
+  let q =
+    query.from(user_schema())
+    |> builder.with_pagination(3, 25)
+
+  query.get_limit(q) |> should.equal(Some(25))
+  query.get_offset(q) |> should.equal(Some(50))
+  // (3-1) * 25
+}
+
+pub fn order_asc_test() {
+  let q =
+    query.from(user_schema())
+    |> builder.order_asc("name")
+
+  let order_bys = query.get_order_bys(q)
+  case order_bys {
+    [ob] -> {
+      ob.field |> should.equal("name")
+      ob.direction |> should.equal(ast.Asc)
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn order_desc_test() {
+  let q =
+    query.from(user_schema())
+    |> builder.order_desc("created_at")
+
+  let order_bys = query.get_order_bys(q)
+  case order_bys {
+    [ob] -> {
+      ob.field |> should.equal("created_at")
+      ob.direction |> should.equal(ast.Desc)
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn with_select_test() {
+  let q =
+    query.from(user_schema())
+    |> builder.with_select(["id", "email"])
+
+  case query.get_select(q) {
+    ast.SelectFields(fields) -> fields |> should.equal(["id", "email"])
+    _ -> should.fail()
+  }
+}
+
+pub fn with_distinct_test() {
+  let q =
+    query.from(user_schema())
+    |> builder.with_distinct()
+
+  query.is_distinct(q) |> should.be_true
+}
+
+// ============================================================================
+// SCOPE TESTS
+// ============================================================================
+
+pub fn scope_test() {
+  let active_scope =
+    builder.scope("active", builder.filter(query.eq_bool("active", True)))
+
+  let q =
+    query.from(user_schema())
+    |> builder.apply_scope(active_scope)
+
+  query.condition_count(q) |> should.equal(1)
+}
+
+pub fn apply_scopes_test() {
+  let active_scope =
+    builder.scope("active", builder.filter(query.eq_bool("active", True)))
+  let adult_scope =
+    builder.scope("adult", builder.filter(query.gt_int("age", 18)))
+
+  let q =
+    query.from(user_schema())
+    |> builder.apply_scopes([active_scope, adult_scope])
+
+  query.condition_count(q) |> should.equal(2)
+}
+
+// ============================================================================
+// COMMON PATTERN TESTS
+// ============================================================================
+
+pub fn not_deleted_test() {
+  let q =
+    query.from(user_schema())
+    |> builder.not_deleted()
+
+  let conditions = query.get_conditions(q)
+  case conditions {
+    [ast.IsNull("deleted_at")] -> should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+pub fn published_test() {
+  let q =
+    query.from(user_schema())
+    |> builder.published()
+
+  let conditions = query.get_conditions(q)
+  case conditions {
+    [ast.Eq("published", ast.BoolValue(True))] -> should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+pub fn active_test() {
+  let q =
+    query.from(user_schema())
+    |> builder.active()
+
+  let conditions = query.get_conditions(q)
+  case conditions {
+    [ast.Eq("active", ast.BoolValue(True))] -> should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+pub fn recent_first_test() {
+  let q =
+    query.from(user_schema())
+    |> builder.recent_first()
+
+  let order_bys = query.get_order_bys(q)
+  case order_bys {
+    [ob] -> {
+      ob.field |> should.equal("created_at")
+      ob.direction |> should.equal(ast.Desc)
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn oldest_first_test() {
+  let q =
+    query.from(user_schema())
+    |> builder.oldest_first()
+
+  let order_bys = query.get_order_bys(q)
+  case order_bys {
+    [ob] -> {
+      ob.field |> should.equal("created_at")
+      ob.direction |> should.equal(ast.Asc)
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn by_user_test() {
+  let q =
+    query.from(user_schema())
+    |> builder.by_user(42)
+
+  let conditions = query.get_conditions(q)
+  case conditions {
+    [ast.Eq("user_id", IntValue(42))] -> should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+// ============================================================================
+// QUERY MERGING TESTS
+// ============================================================================
+
+pub fn merge_conditions_test() {
+  let source =
+    query.from_table("other")
+    |> query.where(query.eq_int("id", 1))
+    |> query.where(query.eq_bool("active", True))
+
+  let target = query.from(user_schema())
+
+  let merged = builder.merge_conditions(target, source)
+
+  query.condition_count(merged) |> should.equal(2)
+}
+
+pub fn merge_order_bys_test() {
+  let source =
+    query.from_table("other")
+    |> query.order_by_desc("created_at")
+
+  let target =
+    query.from(user_schema())
+    |> query.order_by_asc("name")
+
+  let merged = builder.merge_order_bys(target, source)
+
+  let order_bys = query.get_order_bys(merged)
+  order_bys
+  |> list.length
+  |> should.equal(2)
+}
+
+pub fn merge_pagination_preserves_target_test() {
+  let source =
+    query.from_table("other")
+    |> query.limit(100)
+    |> query.offset(50)
+
+  let target =
+    query.from(user_schema())
+    |> query.limit(10)
+
+  let merged = builder.merge_pagination(target, source)
+
+  // Target had limit, should be preserved
+  query.get_limit(merged) |> should.equal(Some(10))
+  // Target had no offset, should use source's
+  query.get_offset(merged) |> should.equal(Some(50))
+}
+
+// ============================================================================
+// QUERY CLONING TESTS
+// ============================================================================
+
+pub fn clone_test() {
+  let q =
+    query.from(user_schema())
+    |> query.where(query.eq_int("id", 1))
+    |> query.limit(10)
+
+  let cloned = builder.clone(q)
+
+  query.condition_count(cloned) |> should.equal(1)
+  query.get_limit(cloned) |> should.equal(Some(10))
+}
+
+pub fn clone_without_conditions_test() {
+  let q =
+    query.from(user_schema())
+    |> query.where(query.eq_int("id", 1))
+    |> query.limit(10)
+
+  let cloned = builder.clone_without_conditions(q)
+
+  query.condition_count(cloned) |> should.equal(0)
+  query.get_limit(cloned) |> should.equal(Some(10))
+}
+
+pub fn clone_without_order_test() {
+  let q =
+    query.from(user_schema())
+    |> query.order_by_desc("created_at")
+    |> query.limit(10)
+
+  let cloned = builder.clone_without_order(q)
+
+  query.has_order_by(cloned) |> should.be_false
+  query.get_limit(cloned) |> should.equal(Some(10))
+}
+
+pub fn clone_without_pagination_test() {
+  let q =
+    query.from(user_schema())
+    |> query.where(query.eq_int("id", 1))
+    |> query.limit(10)
+    |> query.offset(20)
+
+  let cloned = builder.clone_without_pagination(q)
+
+  query.condition_count(cloned) |> should.equal(1)
+  query.has_pagination(cloned) |> should.be_false
+}
+
+// ============================================================================
+// QUERY ANALYSIS TESTS
+// ============================================================================
+
+pub fn conditions_equivalent_test() {
+  let q1 =
+    query.from(user_schema())
+    |> query.where(query.eq_int("id", 1))
+    |> query.where(query.eq_bool("active", True))
+
+  let q2 =
+    query.from_table("other")
+    |> query.where(query.eq_bool("active", True))
+    |> query.where(query.eq_int("id", 1))
+
+  // Same conditions, different order
+  builder.conditions_equivalent(q1, q2) |> should.be_true
+}
+
+pub fn conditions_not_equivalent_test() {
+  let q1 =
+    query.from(user_schema())
+    |> query.where(query.eq_int("id", 1))
+
+  let q2 =
+    query.from_table("other")
+    |> query.where(query.eq_int("id", 2))
+
+  builder.conditions_equivalent(q1, q2) |> should.be_false
+}
+
+pub fn count_conditions_deep_test() {
+  let q =
+    query.from(user_schema())
+    |> query.where(
+      query.and([
+        query.eq_int("id", 1),
+        query.or([query.eq_bool("a", True), query.eq_bool("b", False)]),
+      ]),
+    )
+
+  // 1 AND with 2 children, one of which is an OR with 2 children
+  // Total: 1 (And) + 1 (Eq) + 1 (Or) + 2 (inner Eqs) = 5
+  let count = builder.count_conditions_deep(q)
+  count |> should.equal(5)
+}
+
+pub fn get_condition_fields_test() {
+  let q =
+    query.from(user_schema())
+    |> query.where(query.eq_int("id", 1))
+    |> query.where(query.eq_string("email", "test@example.com"))
+    |> query.where(query.gt_int("age", 18))
+
+  let fields = builder.get_condition_fields(q)
+
+  fields |> list.contains("id") |> should.be_true
+  fields |> list.contains("email") |> should.be_true
+  fields |> list.contains("age") |> should.be_true
+  fields |> list.length |> should.equal(3)
+}
+
+pub fn get_condition_fields_nested_test() {
+  let q =
+    query.from(user_schema())
+    |> query.where(
+      query.and([query.eq_int("id", 1), query.eq_string("name", "test")]),
+    )
+
+  let fields = builder.get_condition_fields(q)
+
+  fields |> list.contains("id") |> should.be_true
+  fields |> list.contains("name") |> should.be_true
+}
+
+// ============================================================================
+// COMPLEX COMPOSITION TESTS
+// ============================================================================
+
+pub fn real_world_composition_test() {
+  // Simulate a real-world query building scenario
+  let base_query = query.from(user_schema())
+
+  // Define reusable scopes
+  let active_users =
+    builder.scope("active", builder.filter(query.eq_bool("active", True)))
+  let adult_users =
+    builder.scope("adult", builder.filter(query.gt_int("age", 18)))
+  let recent_first_scope = builder.scope("recent", builder.recent_first())
+  let paginated = builder.scope("page_1", builder.with_pagination(1, 20))
+
+  // Compose the query
+  let final_query =
+    base_query
+    |> builder.apply_scopes([
+      active_users,
+      adult_users,
+      recent_first_scope,
+      paginated,
+    ])
+
+  // Verify the composed query
+  query.condition_count(final_query) |> should.equal(2)
+  query.has_order_by(final_query) |> should.be_true
+  query.get_limit(final_query) |> should.equal(Some(20))
+  query.get_offset(final_query) |> should.equal(Some(0))
+}
+
+pub fn conditional_composition_test() {
+  // Simulate conditional query building based on user input
+  let include_inactive = False
+  let min_age: option.Option(Int) = Some(21)
+  let sort_by_name = True
+
+  let q =
+    query.from(user_schema())
+    |> builder.when(!include_inactive, builder.active())
+    |> builder.when_some(min_age, fn(age) {
+      builder.filter(query.gt_int("age", age))
+    })
+    |> builder.when(sort_by_name, builder.order_asc("name"))
+
+  // Active filter should be applied (include_inactive is False)
+  // Age filter should be applied (min_age is Some(21))
+  // Sort should be applied
+  query.condition_count(q) |> should.equal(2)
+  query.has_order_by(q) |> should.be_true
+}

--- a/test/cquill/query_test.gleam
+++ b/test/cquill/query_test.gleam
@@ -1,0 +1,723 @@
+import cquill/query.{
+  asc, desc, eq_bool, eq_int, eq_string, gt_int, in_ints, in_strings,
+  is_not_null, is_null, like, lt_int, lte_int, not_eq, nulls_first, nulls_last,
+}
+import cquill/query/ast.{
+  Asc, Desc, Eq, IntValue, NullsFirst, NullsLast, Query as QueryRecord,
+  SelectAll, SelectFields, StringValue, TableSource,
+}
+import cquill/schema
+import cquill/schema/field
+import gleam/list
+import gleam/option.{None, Some}
+import gleeunit
+import gleeunit/should
+
+pub fn main() {
+  gleeunit.main()
+}
+
+// ============================================================================
+// TEST HELPERS
+// ============================================================================
+
+fn user_schema() -> schema.Schema {
+  schema.new("users")
+  |> schema.field(field.integer("id") |> field.primary_key)
+  |> schema.field(field.string("email") |> field.not_null |> field.unique)
+  |> schema.field(field.string("name") |> field.nullable)
+  |> schema.field(field.boolean("active"))
+  |> schema.field(field.integer("age"))
+  |> schema.primary_key(["id"])
+}
+
+// ============================================================================
+// QUERY CONSTRUCTION TESTS
+// ============================================================================
+
+pub fn from_schema_test() {
+  let q = query.from(user_schema())
+
+  case query.get_source(q) {
+    TableSource(table, None) -> table |> should.equal("users")
+    _ -> should.fail()
+  }
+
+  query.get_select(q) |> should.equal(SelectAll)
+  query.get_conditions(q) |> should.equal([])
+  query.get_order_bys(q) |> should.equal([])
+  query.get_limit(q) |> should.equal(None)
+  query.get_offset(q) |> should.equal(None)
+}
+
+pub fn from_table_test() {
+  let q = query.from_table("posts")
+
+  case query.get_source(q) {
+    TableSource(table, None) -> table |> should.equal("posts")
+    _ -> should.fail()
+  }
+}
+
+pub fn from_qualified_test() {
+  let q = query.from_qualified("public", "users")
+
+  case query.get_source(q) {
+    TableSource(table, Some(schema_name)) -> {
+      table |> should.equal("users")
+      schema_name |> should.equal("public")
+    }
+    _ -> should.fail()
+  }
+}
+
+// ============================================================================
+// SELECT TESTS
+// ============================================================================
+
+pub fn select_fields_test() {
+  let q =
+    query.from(user_schema())
+    |> query.select(["id", "email", "name"])
+
+  case query.get_select(q) {
+    SelectFields(fields) -> {
+      fields |> should.equal(["id", "email", "name"])
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn select_all_test() {
+  let q =
+    query.from(user_schema())
+    |> query.select(["id"])
+    |> query.select_all
+
+  query.get_select(q) |> should.equal(SelectAll)
+}
+
+pub fn distinct_test() {
+  let q =
+    query.from(user_schema())
+    |> query.distinct
+
+  query.is_distinct(q) |> should.be_true
+}
+
+// ============================================================================
+// WHERE CONDITION TESTS
+// ============================================================================
+
+pub fn where_single_condition_test() {
+  let q =
+    query.from(user_schema())
+    |> query.where(eq_int("id", 1))
+
+  query.has_conditions(q) |> should.be_true
+  query.condition_count(q) |> should.equal(1)
+
+  let conditions = query.get_conditions(q)
+  case conditions {
+    [Eq("id", IntValue(1))] -> should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+pub fn where_multiple_conditions_test() {
+  let q =
+    query.from(user_schema())
+    |> query.where(eq_bool("active", True))
+    |> query.where(gt_int("age", 18))
+
+  query.condition_count(q) |> should.equal(2)
+}
+
+pub fn where_eq_string_test() {
+  let q =
+    query.from(user_schema())
+    |> query.where(eq_string("email", "test@example.com"))
+
+  let conditions = query.get_conditions(q)
+  case conditions {
+    [Eq("email", StringValue("test@example.com"))] -> should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+pub fn where_or_test() {
+  let q =
+    query.from(user_schema())
+    |> query.where(eq_string("role", "admin"))
+    |> query.or_where(eq_string("role", "moderator"))
+
+  // or_where combines existing conditions with OR
+  query.condition_count(q) |> should.equal(1)
+
+  let conditions = query.get_conditions(q)
+  case conditions {
+    [ast.Or(_)] -> should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+pub fn where_clear_test() {
+  let q =
+    query.from(user_schema())
+    |> query.where(eq_int("id", 1))
+    |> query.where_clear
+
+  query.has_conditions(q) |> should.be_false
+  query.condition_count(q) |> should.equal(0)
+}
+
+pub fn where_replace_test() {
+  let q =
+    query.from(user_schema())
+    |> query.where(eq_int("id", 1))
+    |> query.where(eq_bool("active", True))
+    |> query.where_replace(eq_string("email", "new@example.com"))
+
+  query.condition_count(q) |> should.equal(1)
+
+  let conditions = query.get_conditions(q)
+  case conditions {
+    [Eq("email", StringValue("new@example.com"))] -> should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+// ============================================================================
+// CONDITION BUILDER TESTS
+// ============================================================================
+
+pub fn eq_int_test() {
+  let cond = eq_int("age", 25)
+  case cond {
+    Eq("age", IntValue(25)) -> should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+pub fn not_eq_test() {
+  let cond = not_eq("status", "deleted")
+  case cond {
+    ast.NotEq("status", _) -> should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+pub fn gt_int_test() {
+  let cond = gt_int("age", 18)
+  case cond {
+    ast.Gt("age", IntValue(18)) -> should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+pub fn lt_int_test() {
+  let cond = lt_int("age", 65)
+  case cond {
+    ast.Lt("age", IntValue(65)) -> should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+pub fn lte_int_test() {
+  let cond = lte_int("quantity", 100)
+  case cond {
+    ast.Lte("quantity", IntValue(100)) -> should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+pub fn is_null_test() {
+  let cond = is_null("deleted_at")
+  case cond {
+    ast.IsNull("deleted_at") -> should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+pub fn is_not_null_test() {
+  let cond = is_not_null("email")
+  case cond {
+    ast.IsNotNull("email") -> should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+pub fn in_ints_test() {
+  let cond = in_ints("id", [1, 2, 3])
+  case cond {
+    ast.In("id", values) -> {
+      values
+      |> list.length
+      |> should.equal(3)
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn in_strings_test() {
+  let cond = in_strings("status", ["pending", "approved"])
+  case cond {
+    ast.In("status", values) -> {
+      values
+      |> list.length
+      |> should.equal(2)
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn like_test() {
+  let cond = like("name", "%john%")
+  case cond {
+    ast.Like("name", "%john%") -> should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+pub fn and_conditions_test() {
+  let cond = query.and([eq_bool("active", True), gt_int("age", 18)])
+
+  case cond {
+    ast.And(conditions) -> {
+      conditions
+      |> list.length
+      |> should.equal(2)
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn or_conditions_test() {
+  let cond =
+    query.or([eq_string("role", "admin"), eq_string("role", "moderator")])
+
+  case cond {
+    ast.Or(conditions) -> {
+      conditions
+      |> list.length
+      |> should.equal(2)
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn not_condition_test() {
+  let cond = query.not(eq_bool("deleted", True))
+
+  case cond {
+    ast.Not(inner) -> {
+      case inner {
+        Eq("deleted", _) -> should.be_true(True)
+        _ -> should.fail()
+      }
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn between_test() {
+  let cond = query.between("age", 18, 65)
+
+  case cond {
+    ast.Between("age", _, _) -> should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+// ============================================================================
+// ORDER BY TESTS
+// ============================================================================
+
+pub fn order_by_test() {
+  let q =
+    query.from(user_schema())
+    |> query.order_by("created_at", desc)
+
+  query.has_order_by(q) |> should.be_true
+
+  let order_bys = query.get_order_bys(q)
+  case order_bys {
+    [ob] -> {
+      ob.field |> should.equal("created_at")
+      ob.direction |> should.equal(Desc)
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn order_by_asc_test() {
+  let q =
+    query.from(user_schema())
+    |> query.order_by_asc("name")
+
+  let order_bys = query.get_order_bys(q)
+  case order_bys {
+    [ob] -> {
+      ob.field |> should.equal("name")
+      ob.direction |> should.equal(Asc)
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn order_by_desc_test() {
+  let q =
+    query.from(user_schema())
+    |> query.order_by_desc("created_at")
+
+  let order_bys = query.get_order_bys(q)
+  case order_bys {
+    [ob] -> {
+      ob.field |> should.equal("created_at")
+      ob.direction |> should.equal(Desc)
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn multiple_order_bys_test() {
+  let q =
+    query.from(user_schema())
+    |> query.order_by_desc("created_at")
+    |> query.order_by_asc("name")
+
+  let order_bys = query.get_order_bys(q)
+  order_bys
+  |> list.length
+  |> should.equal(2)
+
+  case order_bys {
+    [first, second] -> {
+      first.field |> should.equal("created_at")
+      second.field |> should.equal("name")
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn order_by_with_nulls_test() {
+  let q =
+    query.from(user_schema())
+    |> query.order_by_with_nulls("score", desc, nulls_last)
+
+  let order_bys = query.get_order_bys(q)
+  case order_bys {
+    [ob] -> {
+      ob.field |> should.equal("score")
+      ob.direction |> should.equal(Desc)
+      ob.nulls |> should.equal(NullsLast)
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn order_by_clear_test() {
+  let q =
+    query.from(user_schema())
+    |> query.order_by_desc("created_at")
+    |> query.order_by_clear
+
+  query.has_order_by(q) |> should.be_false
+}
+
+// ============================================================================
+// PAGINATION TESTS
+// ============================================================================
+
+pub fn limit_test() {
+  let q =
+    query.from(user_schema())
+    |> query.limit(10)
+
+  query.get_limit(q) |> should.equal(Some(10))
+  query.has_pagination(q) |> should.be_true
+}
+
+pub fn offset_test() {
+  let q =
+    query.from(user_schema())
+    |> query.offset(20)
+
+  query.get_offset(q) |> should.equal(Some(20))
+  query.has_pagination(q) |> should.be_true
+}
+
+pub fn limit_and_offset_test() {
+  let q =
+    query.from(user_schema())
+    |> query.limit(10)
+    |> query.offset(20)
+
+  query.get_limit(q) |> should.equal(Some(10))
+  query.get_offset(q) |> should.equal(Some(20))
+}
+
+pub fn paginate_test() {
+  // Page 3 with 10 items per page
+  let q =
+    query.from(user_schema())
+    |> query.paginate(page: 3, per_page: 10)
+
+  query.get_limit(q) |> should.equal(Some(10))
+  query.get_offset(q) |> should.equal(Some(20))
+  // (3-1) * 10 = 20
+}
+
+pub fn paginate_first_page_test() {
+  let q =
+    query.from(user_schema())
+    |> query.paginate(page: 1, per_page: 25)
+
+  query.get_limit(q) |> should.equal(Some(25))
+  query.get_offset(q) |> should.equal(Some(0))
+}
+
+pub fn no_pagination_test() {
+  let q =
+    query.from(user_schema())
+    |> query.limit(10)
+    |> query.offset(20)
+    |> query.no_pagination
+
+  query.get_limit(q) |> should.equal(None)
+  query.get_offset(q) |> should.equal(None)
+  query.has_pagination(q) |> should.be_false
+}
+
+// ============================================================================
+// JOIN TESTS
+// ============================================================================
+
+pub fn inner_join_test() {
+  let q =
+    query.from(user_schema())
+    |> query.join("posts", on: eq_int("posts.user_id", 1))
+
+  let joins = query.get_joins(q)
+  joins
+  |> list.length
+  |> should.equal(1)
+
+  case joins {
+    [join] -> {
+      join.join_type |> should.equal(ast.InnerJoin)
+      join.table |> should.equal("posts")
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn left_join_test() {
+  let q =
+    query.from(user_schema())
+    |> query.left_join("posts", on: eq_int("posts.user_id", 1))
+
+  let joins = query.get_joins(q)
+  case joins {
+    [join] -> join.join_type |> should.equal(ast.LeftJoin)
+    _ -> should.fail()
+  }
+}
+
+pub fn join_with_alias_test() {
+  let q =
+    query.from(user_schema())
+    |> query.join_as("posts", alias: "p", on: eq_int("p.user_id", 1))
+
+  let joins = query.get_joins(q)
+  case joins {
+    [join] -> {
+      join.table |> should.equal("posts")
+      join.table_alias |> should.equal(Some("p"))
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn multiple_joins_test() {
+  let q =
+    query.from(user_schema())
+    |> query.join("posts", on: eq_int("posts.user_id", 1))
+    |> query.left_join("comments", on: eq_int("comments.post_id", 1))
+
+  let joins = query.get_joins(q)
+  joins
+  |> list.length
+  |> should.equal(2)
+}
+
+// ============================================================================
+// GROUP BY / HAVING TESTS
+// ============================================================================
+
+pub fn group_by_test() {
+  let q =
+    query.from(user_schema())
+    |> query.group_by("role")
+
+  let QueryRecord(group_bys:, ..) = q
+  group_bys |> should.equal(["role"])
+}
+
+pub fn group_by_multiple_test() {
+  let q =
+    query.from(user_schema())
+    |> query.group_by_fields(["role", "status"])
+
+  let QueryRecord(group_bys:, ..) = q
+  group_bys |> should.equal(["role", "status"])
+}
+
+pub fn having_test() {
+  let q =
+    query.from(user_schema())
+    |> query.group_by("role")
+    |> query.having(gt_int("count", 5))
+
+  let QueryRecord(havings:, ..) = q
+  havings
+  |> list.length
+  |> should.equal(1)
+}
+
+// ============================================================================
+// COMPOSABILITY TESTS
+// ============================================================================
+
+pub fn pipeline_composition_test() {
+  // Demonstrate that queries can be built with pipelines
+  let q =
+    query.from(user_schema())
+    |> query.select(["id", "email", "name"])
+    |> query.where(eq_bool("active", True))
+    |> query.where(gt_int("age", 18))
+    |> query.order_by_desc("created_at")
+    |> query.limit(10)
+
+  // Verify all parts are set correctly
+  case query.get_select(q) {
+    SelectFields(fields) -> fields |> should.equal(["id", "email", "name"])
+    _ -> should.fail()
+  }
+
+  query.condition_count(q) |> should.equal(2)
+  query.has_order_by(q) |> should.be_true
+  query.get_limit(q) |> should.equal(Some(10))
+}
+
+pub fn reusable_filter_composition_test() {
+  // Define reusable filters as functions
+  let active = fn(q) { query.where(q, eq_bool("active", True)) }
+  let adult = fn(q) { query.where(q, gt_int("age", 18)) }
+  let recent_first = fn(q) { query.order_by_desc(q, "created_at") }
+
+  // Compose them
+  let q =
+    query.from(user_schema())
+    |> active
+    |> adult
+    |> recent_first
+    |> query.limit(10)
+
+  query.condition_count(q) |> should.equal(2)
+  query.has_order_by(q) |> should.be_true
+  query.get_limit(q) |> should.equal(Some(10))
+}
+
+// ============================================================================
+// QUERY INSPECTION TESTS
+// ============================================================================
+
+pub fn has_conditions_test() {
+  let q1 = query.from(user_schema())
+  query.has_conditions(q1) |> should.be_false
+
+  let q2 =
+    query.from(user_schema())
+    |> query.where(eq_int("id", 1))
+  query.has_conditions(q2) |> should.be_true
+}
+
+pub fn has_order_by_test() {
+  let q1 = query.from(user_schema())
+  query.has_order_by(q1) |> should.be_false
+
+  let q2 =
+    query.from(user_schema())
+    |> query.order_by_asc("name")
+  query.has_order_by(q2) |> should.be_true
+}
+
+pub fn has_pagination_test() {
+  let q1 = query.from(user_schema())
+  query.has_pagination(q1) |> should.be_false
+
+  let q2 =
+    query.from(user_schema())
+    |> query.limit(10)
+  query.has_pagination(q2) |> should.be_true
+
+  let q3 =
+    query.from(user_schema())
+    |> query.offset(5)
+  query.has_pagination(q3) |> should.be_true
+}
+
+pub fn is_distinct_test() {
+  let q1 = query.from(user_schema())
+  query.is_distinct(q1) |> should.be_false
+
+  let q2 =
+    query.from(user_schema())
+    |> query.distinct
+  query.is_distinct(q2) |> should.be_true
+}
+
+// ============================================================================
+// DEBUG STRING TESTS
+// ============================================================================
+
+pub fn to_debug_string_basic_test() {
+  let q = query.from_table("users")
+  let debug = query.to_debug_string(q)
+
+  // Should contain the table name
+  debug
+  |> string.contains("users")
+  |> should.be_true
+}
+
+pub fn to_debug_string_with_conditions_test() {
+  let q =
+    query.from_table("users")
+    |> query.where(eq_int("id", 1))
+
+  let debug = query.to_debug_string(q)
+
+  debug
+  |> string.contains("id = 1")
+  |> should.be_true
+}
+
+pub fn to_debug_string_with_select_test() {
+  let q =
+    query.from_table("users")
+    |> query.select(["id", "email"])
+
+  let debug = query.to_debug_string(q)
+
+  debug
+  |> string.contains("id, email")
+  |> should.be_true
+}
+
+// ============================================================================
+// IMPORTS FOR TESTS
+// ============================================================================
+
+import gleam/string


### PR DESCRIPTION
## Summary
- Implement Query AST types in `src/cquill/query/ast.gleam`
- Add pipeline-friendly query builder API in `src/cquill/query.gleam`
- Add reusable composition functions in `src/cquill/query/builder.gleam`
- Add FFI for value type coercion (Erlang and JavaScript)
- Add comprehensive unit tests (116 new tests, 216 total)

## Architecture

The Query layer is **pure** - builds AST only, no SQL generation, no I/O.

```
src/cquill/
├── query.gleam           # Main query builder entry point
└── query/
    ├── ast.gleam         # Query AST types
    └── builder.gleam     # Composition functions
```

## Key Features

### Query AST Types
- `Query(schema)` - Main query structure with source, select, wheres, joins, etc.
- `Condition` - Full condition types (Eq, NotEq, Gt, Lt, In, Like, IsNull, And, Or, Not)
- `Value` - Type-safe values (IntValue, StringValue, BoolValue, etc.)
- `OrderBy` with Direction (Asc/Desc) and NullsOrder
- `Join` with JoinType (Inner, Left, Right, Full, Cross)
- `Select` variants (SelectAll, SelectFields, SelectExpr)

### Builder API
- `from(schema)` - Create query from schema
- `select(fields)` - Select specific fields
- `where(condition)` / `or_where(condition)` - Add conditions
- `order_by(field, direction)` - Add ordering
- `limit(n)` / `offset(n)` / `paginate(page, per_page)` - Pagination
- `join(table, on:)` / `left_join(table, on:)` - Joins

### Condition Builders
- Type-safe: `eq_int`, `eq_string`, `eq_bool`, `gt_int`, `lt_int`
- Flexible: `in_ints`, `in_strings`, `like`, `is_null`, `is_not_null`
- Composable: `and([...])`, `or([...])`, `not(condition)`

### Composition Functions
- `filter(condition)` - Create reusable filter modifiers
- `compose([modifiers])` - Combine multiple modifiers
- `when(bool, modifier)` - Conditional application
- `when_some(option, factory)` - Apply based on optional value
- Named scopes: `scope(name, modifier)`, `apply_scopes(query, scopes)`
- Common patterns: `active()`, `published()`, `not_deleted()`, `recent_first()`

## Test Plan

- [x] All 216 tests pass (`gleam test`)
- [x] Code formatted (`gleam format --check`)
- [x] Query AST types correctly represent all conditions
- [x] Builder API is pipeline-friendly
- [x] Composition functions combine properly
- [x] Query inspection works for testing

## Example Usage

```gleam
import cquill/query
import cquill/query/builder

// Base query from schema
let users = query.from(user_schema)

// Reusable filters
let active = builder.filter(query.eq_bool("active", True))
let adult = builder.filter(query.gt_int("age", 18))
let recent_first = builder.recent_first()

// Compose with pipelines
let results = users
  |> active
  |> adult
  |> recent_first
  |> query.paginate(page: 1, per_page: 20)

// Or use scopes
let active_scope = builder.scope("active", active)
let adult_scope = builder.scope("adult", adult)

let results = query.from(user_schema)
  |> builder.apply_scopes([active_scope, adult_scope])
  |> query.limit(10)

// Conditional composition
let q = query.from(user_schema)
  |> builder.when(include_inactive == False, builder.active())
  |> builder.when_some(min_age, fn(age) { builder.filter(query.gt_int("age", age)) })
```

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)