### PR TITLE
Implement type mapping from Postgres to Gleam

### DIFF
--- a/src/cquill/codegen/type_mapping.gleam
+++ b/src/cquill/codegen/type_mapping.gleam
@@ -1,0 +1,611 @@
+// Type Mapping Module
+//
+// This module provides type mapping logic that converts PostgreSQL column types
+// to appropriate Gleam types for code generation.
+//
+// Usage:
+// 1. Get introspected columns from the introspection module
+// 2. Use map_column() to get full column metadata including Gleam type
+// 3. Use the GleamType for code generation
+//
+// Features:
+// - Maps all common PostgreSQL types to Gleam types
+// - Handles nullable columns with Option wrapper
+// - Handles arrays with List wrapper
+// - Detects custom enum types
+// - Tracks auto-generated columns (serial, defaults)
+
+import gleam/list
+import gleam/option.{type Option, None, Some}
+import gleam/result
+import gleam/string
+
+// ============================================================================
+// GLEAM TYPE REPRESENTATION
+// ============================================================================
+
+/// Represents a Gleam type that a PostgreSQL column maps to
+pub type GleamType {
+  /// Gleam Int (for integer, smallint, bigint, serial, bigserial)
+  GleamInt
+  /// Gleam Float (for real, double precision)
+  GleamFloat
+  /// Gleam String (for varchar, char, text)
+  GleamString
+  /// Gleam Bool (for boolean)
+  GleamBool
+  /// Gleam BitArray (for bytea)
+  GleamBitArray
+  /// Time type (for timestamp with/without time zone)
+  GleamTime
+  /// Date type (for date)
+  GleamDate
+  /// Time of day type (for time with/without time zone)
+  GleamTimeOfDay
+  /// Decimal type (for numeric, decimal) - external package
+  GleamDecimal
+  /// UUID type - typically a newtype wrapper around String
+  GleamUuid
+  /// JSON type (for json, jsonb) - opaque type
+  GleamJson
+  /// List type for PostgreSQL arrays
+  GleamList(element_type: GleamType)
+  /// Option type for nullable columns
+  GleamOption(inner_type: GleamType)
+  /// Custom type (for user-defined enums or types)
+  GleamCustom(module: String, type_name: String)
+}
+
+// ============================================================================
+// COLUMN METADATA
+// ============================================================================
+
+/// Extended column metadata including Gleam type and generation info
+pub type ColumnMeta {
+  ColumnMeta(
+    /// The mapped Gleam type
+    gleam_type: GleamType,
+    /// Whether this column is auto-generated (serial, has default, etc.)
+    /// Auto-generated columns are excluded from insert types
+    is_auto_generated: Bool,
+    /// The original PostgreSQL data type
+    postgres_type: String,
+    /// The underlying type name (useful for enums)
+    udt_name: String,
+    /// Column name
+    column_name: String,
+    /// Whether the column is nullable
+    is_nullable: Bool,
+  )
+}
+
+// ============================================================================
+// ERROR TYPES
+// ============================================================================
+
+/// Errors that can occur during type mapping
+pub type TypeMappingError {
+  /// Unknown PostgreSQL type that cannot be mapped
+  UnknownType(postgres_type: String, udt_name: String)
+  /// Array type with unsupported element type
+  UnsupportedArray(element_type: String)
+}
+
+// ============================================================================
+// TYPE MAPPING FUNCTIONS
+// ============================================================================
+
+/// Map a PostgreSQL column to its corresponding Gleam type
+///
+/// Parameters:
+/// - data_type: The PostgreSQL data type (e.g., "integer", "character varying")
+/// - udt_name: The underlying type name (e.g., "int4", "varchar", or enum name)
+/// - is_nullable: Whether the column allows NULL values
+/// - enum_names: List of known enum type names in the schema
+///
+/// Returns:
+/// - Ok(GleamType) with the mapped type (wrapped in Option if nullable)
+/// - Error(TypeMappingError) if the type cannot be mapped
+pub fn map_postgres_type(
+  data_type: String,
+  udt_name: String,
+  is_nullable: Bool,
+  enum_names: List(String),
+) -> Result(GleamType, TypeMappingError) {
+  // First, map the base type
+  use base_type <- result.try(map_base_type(data_type, udt_name, enum_names))
+
+  // Wrap in Option if nullable
+  let final_type = case is_nullable {
+    True -> GleamOption(base_type)
+    False -> base_type
+  }
+
+  Ok(final_type)
+}
+
+/// Map a PostgreSQL type to a base Gleam type (without Option wrapper)
+fn map_base_type(
+  data_type: String,
+  udt_name: String,
+  enum_names: List(String),
+) -> Result(GleamType, TypeMappingError) {
+  let lowercase_data_type = string.lowercase(data_type)
+  let lowercase_udt_name = string.lowercase(udt_name)
+
+  case lowercase_data_type {
+    // Integer types
+    "integer" | "int" | "int4" -> Ok(GleamInt)
+    "smallint" | "int2" -> Ok(GleamInt)
+    "bigint" | "int8" -> Ok(GleamInt)
+
+    // Serial types (auto-incrementing integers)
+    "serial" | "serial4" -> Ok(GleamInt)
+    "smallserial" | "serial2" -> Ok(GleamInt)
+    "bigserial" | "serial8" -> Ok(GleamInt)
+
+    // Floating point types
+    "real" | "float4" -> Ok(GleamFloat)
+    "double precision" | "float8" -> Ok(GleamFloat)
+
+    // Decimal types (for precision)
+    "numeric" | "decimal" -> Ok(GleamDecimal)
+
+    // String types
+    "character varying" | "varchar" -> Ok(GleamString)
+    "character" | "char" | "bpchar" -> Ok(GleamString)
+    "text" -> Ok(GleamString)
+    "name" -> Ok(GleamString)
+
+    // Boolean
+    "boolean" | "bool" -> Ok(GleamBool)
+
+    // Binary data
+    "bytea" -> Ok(GleamBitArray)
+
+    // Timestamp types
+    "timestamp without time zone" | "timestamp" -> Ok(GleamTime)
+    "timestamp with time zone" | "timestamptz" -> Ok(GleamTime)
+
+    // Date type
+    "date" -> Ok(GleamDate)
+
+    // Time types
+    "time without time zone" | "time" -> Ok(GleamTimeOfDay)
+    "time with time zone" | "timetz" -> Ok(GleamTimeOfDay)
+
+    // Interval (map to String for now, could be custom type)
+    "interval" -> Ok(GleamString)
+
+    // UUID
+    "uuid" -> Ok(GleamUuid)
+
+    // JSON types
+    "json" -> Ok(GleamJson)
+    "jsonb" -> Ok(GleamJson)
+
+    // Array types - detected by ARRAY data_type or _ prefix in udt_name
+    "array" -> map_array_type(lowercase_udt_name, enum_names)
+
+    // User-defined types (enums)
+    "user-defined" -> map_user_defined_type(udt_name, enum_names)
+
+    // Try to match by udt_name for cases where data_type isn't specific
+    _ -> map_by_udt_name(lowercase_udt_name, enum_names)
+  }
+}
+
+/// Map an array type based on its element type (from udt_name with _ prefix)
+fn map_array_type(
+  udt_name: String,
+  enum_names: List(String),
+) -> Result(GleamType, TypeMappingError) {
+  // PostgreSQL array types have udt_name starting with underscore
+  // e.g., _int4 for integer[], _varchar for varchar[]
+  case string.starts_with(udt_name, "_") {
+    True -> {
+      let element_udt = string.drop_start(udt_name, 1)
+      case map_element_type(element_udt, enum_names) {
+        Ok(element_type) -> Ok(GleamList(element_type))
+        Error(_) -> Error(UnsupportedArray(element_udt))
+      }
+    }
+    False -> Error(UnsupportedArray(udt_name))
+  }
+}
+
+/// Map array element types
+fn map_element_type(
+  element_udt: String,
+  enum_names: List(String),
+) -> Result(GleamType, TypeMappingError) {
+  let lowercase_udt = string.lowercase(element_udt)
+
+  case lowercase_udt {
+    // Integer types
+    "int4" | "int" | "integer" -> Ok(GleamInt)
+    "int2" | "smallint" -> Ok(GleamInt)
+    "int8" | "bigint" -> Ok(GleamInt)
+
+    // Float types
+    "float4" | "real" -> Ok(GleamFloat)
+    "float8" | "double precision" -> Ok(GleamFloat)
+
+    // Decimal
+    "numeric" | "decimal" -> Ok(GleamDecimal)
+
+    // String types
+    "varchar" | "character varying" -> Ok(GleamString)
+    "bpchar" | "char" | "character" -> Ok(GleamString)
+    "text" -> Ok(GleamString)
+    "name" -> Ok(GleamString)
+
+    // Boolean
+    "bool" | "boolean" -> Ok(GleamBool)
+
+    // Binary
+    "bytea" -> Ok(GleamBitArray)
+
+    // Timestamp
+    "timestamp" | "timestamptz" -> Ok(GleamTime)
+
+    // Date
+    "date" -> Ok(GleamDate)
+
+    // Time
+    "time" | "timetz" -> Ok(GleamTimeOfDay)
+
+    // UUID
+    "uuid" -> Ok(GleamUuid)
+
+    // JSON
+    "json" | "jsonb" -> Ok(GleamJson)
+
+    // Check if it's a custom enum
+    _ -> {
+      case list.contains(enum_names, element_udt) {
+        True ->
+          Ok(GleamCustom(
+            module: "schema/enums",
+            type_name: pascal_case(element_udt),
+          ))
+        False -> Error(UnknownType(element_udt, element_udt))
+      }
+    }
+  }
+}
+
+/// Map user-defined types (primarily enums)
+fn map_user_defined_type(
+  udt_name: String,
+  enum_names: List(String),
+) -> Result(GleamType, TypeMappingError) {
+  // Check if this is a known enum
+  case list.contains(enum_names, udt_name) {
+    True ->
+      Ok(GleamCustom(module: "schema/enums", type_name: pascal_case(udt_name)))
+    False -> {
+      // Could be another user-defined type, treat as custom
+      Ok(GleamCustom(module: "schema/types", type_name: pascal_case(udt_name)))
+    }
+  }
+}
+
+/// Try to map by udt_name when data_type is not specific enough
+fn map_by_udt_name(
+  udt_name: String,
+  enum_names: List(String),
+) -> Result(GleamType, TypeMappingError) {
+  case udt_name {
+    // Integer types
+    "int4" | "int" -> Ok(GleamInt)
+    "int2" -> Ok(GleamInt)
+    "int8" -> Ok(GleamInt)
+
+    // Float types
+    "float4" -> Ok(GleamFloat)
+    "float8" -> Ok(GleamFloat)
+
+    // Decimal
+    "numeric" -> Ok(GleamDecimal)
+
+    // String types
+    "varchar" -> Ok(GleamString)
+    "bpchar" -> Ok(GleamString)
+    "text" -> Ok(GleamString)
+    "name" -> Ok(GleamString)
+
+    // Boolean
+    "bool" -> Ok(GleamBool)
+
+    // Binary
+    "bytea" -> Ok(GleamBitArray)
+
+    // Timestamp
+    "timestamp" | "timestamptz" -> Ok(GleamTime)
+
+    // Date
+    "date" -> Ok(GleamDate)
+
+    // Time
+    "time" | "timetz" -> Ok(GleamTimeOfDay)
+
+    // UUID
+    "uuid" -> Ok(GleamUuid)
+
+    // JSON
+    "json" | "jsonb" -> Ok(GleamJson)
+
+    // Check for array types (start with underscore) or enums
+    _ -> {
+      case string.starts_with(udt_name, "_") {
+        True -> map_array_type(udt_name, enum_names)
+        False -> {
+          case list.contains(enum_names, udt_name) {
+            True ->
+              Ok(GleamCustom(
+                module: "schema/enums",
+                type_name: pascal_case(udt_name),
+              ))
+            False -> Error(UnknownType("unknown", udt_name))
+          }
+        }
+      }
+    }
+  }
+}
+
+// ============================================================================
+// COLUMN METADATA MAPPING
+// ============================================================================
+
+/// Map an introspected column to full column metadata
+///
+/// Parameters:
+/// - column_name: The column name
+/// - data_type: PostgreSQL data type
+/// - udt_name: Underlying type name
+/// - is_nullable: Whether the column allows NULL
+/// - column_default: Default value expression (if any)
+/// - enum_names: List of known enum type names
+///
+/// Returns:
+/// - Ok(ColumnMeta) with full metadata
+/// - Error(TypeMappingError) if type cannot be mapped
+pub fn map_column(
+  column_name: String,
+  data_type: String,
+  udt_name: String,
+  is_nullable: Bool,
+  column_default: Option(String),
+  enum_names: List(String),
+) -> Result(ColumnMeta, TypeMappingError) {
+  use gleam_type <- result.try(map_postgres_type(
+    data_type,
+    udt_name,
+    is_nullable,
+    enum_names,
+  ))
+
+  let is_auto_generated = detect_auto_generated(data_type, column_default)
+
+  Ok(ColumnMeta(
+    gleam_type:,
+    is_auto_generated:,
+    postgres_type: data_type,
+    udt_name:,
+    column_name:,
+    is_nullable:,
+  ))
+}
+
+/// Detect if a column is auto-generated based on type and default
+fn detect_auto_generated(
+  data_type: String,
+  column_default: Option(String),
+) -> Bool {
+  let lowercase_type = string.lowercase(data_type)
+
+  // Serial types are always auto-generated
+  let is_serial = case lowercase_type {
+    "serial" | "serial2" | "serial4" | "smallserial" | "bigserial" | "serial8" ->
+      True
+    _ -> False
+  }
+
+  // Check for sequence-based defaults (nextval)
+  let has_sequence_default = case column_default {
+    Some(default_expr) ->
+      string.contains(string.lowercase(default_expr), "nextval")
+    None -> False
+  }
+
+  // Check for other auto-generated defaults
+  let has_auto_default = case column_default {
+    Some(default_expr) -> {
+      let lower = string.lowercase(default_expr)
+      string.contains(lower, "now()")
+      || string.contains(lower, "current_timestamp")
+      || string.contains(lower, "current_date")
+      || string.contains(lower, "gen_random_uuid")
+      || string.contains(lower, "uuid_generate")
+    }
+    None -> False
+  }
+
+  is_serial || has_sequence_default || has_auto_default
+}
+
+// ============================================================================
+// TYPE RENDERING FUNCTIONS
+// ============================================================================
+
+/// Render a GleamType as a Gleam type string for code generation
+pub fn render_type(gleam_type: GleamType) -> String {
+  case gleam_type {
+    GleamInt -> "Int"
+    GleamFloat -> "Float"
+    GleamString -> "String"
+    GleamBool -> "Bool"
+    GleamBitArray -> "BitArray"
+    GleamTime -> "Time"
+    GleamDate -> "Date"
+    GleamTimeOfDay -> "TimeOfDay"
+    GleamDecimal -> "Decimal"
+    GleamUuid -> "Uuid"
+    GleamJson -> "Json"
+    GleamList(element_type) -> "List(" <> render_type(element_type) <> ")"
+    GleamOption(inner_type) -> "Option(" <> render_type(inner_type) <> ")"
+    GleamCustom(_module, type_name) -> type_name
+  }
+}
+
+/// Render a GleamType as a fully qualified Gleam type string (with imports)
+pub fn render_qualified_type(gleam_type: GleamType) -> String {
+  case gleam_type {
+    GleamInt -> "Int"
+    GleamFloat -> "Float"
+    GleamString -> "String"
+    GleamBool -> "Bool"
+    GleamBitArray -> "BitArray"
+    GleamTime -> "birl.Time"
+    GleamDate -> "birl.Date"
+    GleamTimeOfDay -> "birl.TimeOfDay"
+    GleamDecimal -> "decimal.Decimal"
+    GleamUuid -> "uuid.Uuid"
+    GleamJson -> "json.Json"
+    GleamList(element_type) ->
+      "List(" <> render_qualified_type(element_type) <> ")"
+    GleamOption(inner_type) ->
+      "option.Option(" <> render_qualified_type(inner_type) <> ")"
+    GleamCustom(module, type_name) -> module <> "." <> type_name
+  }
+}
+
+/// Get the imports needed for a GleamType
+pub fn get_imports(gleam_type: GleamType) -> List(String) {
+  case gleam_type {
+    GleamInt | GleamFloat | GleamString | GleamBool | GleamBitArray -> []
+    GleamTime | GleamDate | GleamTimeOfDay -> ["birl"]
+    GleamDecimal -> ["decimal"]
+    GleamUuid -> ["uuid"]
+    GleamJson -> ["gleam/json"]
+    GleamList(element_type) -> get_imports(element_type)
+    GleamOption(inner_type) -> ["gleam/option", ..get_imports(inner_type)]
+    GleamCustom(module, _) -> [module]
+  }
+}
+
+/// Collect all unique imports needed for a list of column metadata
+pub fn collect_imports(columns: List(ColumnMeta)) -> List(String) {
+  columns
+  |> list.flat_map(fn(col) { get_imports(col.gleam_type) })
+  |> list.unique
+  |> list.sort(string.compare)
+}
+
+// ============================================================================
+// UTILITY FUNCTIONS
+// ============================================================================
+
+/// Convert snake_case to PascalCase
+pub fn pascal_case(input: String) -> String {
+  input
+  |> string.split("_")
+  |> list.map(capitalize_first)
+  |> string.join("")
+}
+
+/// Capitalize the first letter of a string
+fn capitalize_first(s: String) -> String {
+  case string.pop_grapheme(s) {
+    Ok(#(first, rest)) -> string.uppercase(first) <> rest
+    Error(_) -> s
+  }
+}
+
+/// Convert PascalCase or snake_case to snake_case
+pub fn snake_case(input: String) -> String {
+  input
+  |> string.to_graphemes
+  |> list.index_fold("", fn(acc, char, index) {
+    case is_uppercase(char), index {
+      True, 0 -> string.lowercase(char)
+      True, _ -> acc <> "_" <> string.lowercase(char)
+      False, _ -> acc <> char
+    }
+  })
+}
+
+/// Check if a character is uppercase
+fn is_uppercase(char: String) -> Bool {
+  char == string.uppercase(char) && char != string.lowercase(char)
+}
+
+// ============================================================================
+// TYPE CHECKING FUNCTIONS
+// ============================================================================
+
+/// Check if a GleamType is nullable (wrapped in Option)
+pub fn is_nullable_type(gleam_type: GleamType) -> Bool {
+  case gleam_type {
+    GleamOption(_) -> True
+    _ -> False
+  }
+}
+
+/// Check if a GleamType is a list type
+pub fn is_list_type(gleam_type: GleamType) -> Bool {
+  case gleam_type {
+    GleamList(_) -> True
+    _ -> False
+  }
+}
+
+/// Check if a GleamType is a custom type (enum or user-defined)
+pub fn is_custom_type(gleam_type: GleamType) -> Bool {
+  case gleam_type {
+    GleamCustom(_, _) -> True
+    GleamOption(GleamCustom(_, _)) -> True
+    GleamList(GleamCustom(_, _)) -> True
+    _ -> False
+  }
+}
+
+/// Get the inner type from an Option type
+pub fn unwrap_option(gleam_type: GleamType) -> GleamType {
+  case gleam_type {
+    GleamOption(inner) -> inner
+    other -> other
+  }
+}
+
+/// Get the element type from a List type
+pub fn unwrap_list(gleam_type: GleamType) -> GleamType {
+  case gleam_type {
+    GleamList(element) -> element
+    other -> other
+  }
+}
+
+/// Check if two GleamTypes are equal
+pub fn types_equal(type_a: GleamType, type_b: GleamType) -> Bool {
+  case type_a, type_b {
+    GleamInt, GleamInt -> True
+    GleamFloat, GleamFloat -> True
+    GleamString, GleamString -> True
+    GleamBool, GleamBool -> True
+    GleamBitArray, GleamBitArray -> True
+    GleamTime, GleamTime -> True
+    GleamDate, GleamDate -> True
+    GleamTimeOfDay, GleamTimeOfDay -> True
+    GleamDecimal, GleamDecimal -> True
+    GleamUuid, GleamUuid -> True
+    GleamJson, GleamJson -> True
+    GleamList(a), GleamList(b) -> types_equal(a, b)
+    GleamOption(a), GleamOption(b) -> types_equal(a, b)
+    GleamCustom(mod_a, name_a), GleamCustom(mod_b, name_b) ->
+      mod_a == mod_b && name_a == name_b
+    _, _ -> False
+  }
+}

--- a/test/cquill/codegen/type_mapping_test.gleam
+++ b/test/cquill/codegen/type_mapping_test.gleam
@@ -1,0 +1,879 @@
+// Tests for the type mapping module
+//
+// These tests verify:
+// - All standard PostgreSQL types map correctly
+// - Nullable types are wrapped in Option
+// - Arrays map to List
+// - Unknown types produce clear errors
+// - Serial types marked as auto-generated
+// - Custom enum detection
+// - Type rendering for code generation
+
+import cquill/codegen/type_mapping.{
+  type ColumnMeta, ColumnMeta, GleamBitArray, GleamBool, GleamCustom, GleamDate,
+  GleamDecimal, GleamFloat, GleamInt, GleamJson, GleamList, GleamOption,
+  GleamString, GleamTime, GleamTimeOfDay, GleamUuid, UnknownType,
+  UnsupportedArray,
+}
+import gleam/option.{None, Some}
+import gleeunit
+import gleeunit/should
+
+pub fn main() {
+  gleeunit.main()
+}
+
+// ============================================================================
+// INTEGER TYPE MAPPING TESTS
+// ============================================================================
+
+pub fn map_integer_test() {
+  type_mapping.map_postgres_type("integer", "int4", False, [])
+  |> should.be_ok
+  |> should.equal(GleamInt)
+}
+
+pub fn map_int_test() {
+  type_mapping.map_postgres_type("int", "int4", False, [])
+  |> should.be_ok
+  |> should.equal(GleamInt)
+}
+
+pub fn map_int4_test() {
+  type_mapping.map_postgres_type("int4", "int4", False, [])
+  |> should.be_ok
+  |> should.equal(GleamInt)
+}
+
+pub fn map_smallint_test() {
+  type_mapping.map_postgres_type("smallint", "int2", False, [])
+  |> should.be_ok
+  |> should.equal(GleamInt)
+}
+
+pub fn map_bigint_test() {
+  type_mapping.map_postgres_type("bigint", "int8", False, [])
+  |> should.be_ok
+  |> should.equal(GleamInt)
+}
+
+pub fn map_serial_test() {
+  type_mapping.map_postgres_type("serial", "serial4", False, [])
+  |> should.be_ok
+  |> should.equal(GleamInt)
+}
+
+pub fn map_bigserial_test() {
+  type_mapping.map_postgres_type("bigserial", "serial8", False, [])
+  |> should.be_ok
+  |> should.equal(GleamInt)
+}
+
+pub fn map_smallserial_test() {
+  type_mapping.map_postgres_type("smallserial", "serial2", False, [])
+  |> should.be_ok
+  |> should.equal(GleamInt)
+}
+
+// ============================================================================
+// FLOAT TYPE MAPPING TESTS
+// ============================================================================
+
+pub fn map_real_test() {
+  type_mapping.map_postgres_type("real", "float4", False, [])
+  |> should.be_ok
+  |> should.equal(GleamFloat)
+}
+
+pub fn map_double_precision_test() {
+  type_mapping.map_postgres_type("double precision", "float8", False, [])
+  |> should.be_ok
+  |> should.equal(GleamFloat)
+}
+
+pub fn map_float4_test() {
+  type_mapping.map_postgres_type("float4", "float4", False, [])
+  |> should.be_ok
+  |> should.equal(GleamFloat)
+}
+
+pub fn map_float8_test() {
+  type_mapping.map_postgres_type("float8", "float8", False, [])
+  |> should.be_ok
+  |> should.equal(GleamFloat)
+}
+
+// ============================================================================
+// DECIMAL TYPE MAPPING TESTS
+// ============================================================================
+
+pub fn map_numeric_test() {
+  type_mapping.map_postgres_type("numeric", "numeric", False, [])
+  |> should.be_ok
+  |> should.equal(GleamDecimal)
+}
+
+pub fn map_decimal_test() {
+  type_mapping.map_postgres_type("decimal", "numeric", False, [])
+  |> should.be_ok
+  |> should.equal(GleamDecimal)
+}
+
+// ============================================================================
+// STRING TYPE MAPPING TESTS
+// ============================================================================
+
+pub fn map_varchar_test() {
+  type_mapping.map_postgres_type("character varying", "varchar", False, [])
+  |> should.be_ok
+  |> should.equal(GleamString)
+}
+
+pub fn map_char_test() {
+  type_mapping.map_postgres_type("character", "bpchar", False, [])
+  |> should.be_ok
+  |> should.equal(GleamString)
+}
+
+pub fn map_bpchar_test() {
+  type_mapping.map_postgres_type("bpchar", "bpchar", False, [])
+  |> should.be_ok
+  |> should.equal(GleamString)
+}
+
+pub fn map_text_test() {
+  type_mapping.map_postgres_type("text", "text", False, [])
+  |> should.be_ok
+  |> should.equal(GleamString)
+}
+
+pub fn map_name_test() {
+  type_mapping.map_postgres_type("name", "name", False, [])
+  |> should.be_ok
+  |> should.equal(GleamString)
+}
+
+// ============================================================================
+// BOOLEAN TYPE MAPPING TESTS
+// ============================================================================
+
+pub fn map_boolean_test() {
+  type_mapping.map_postgres_type("boolean", "bool", False, [])
+  |> should.be_ok
+  |> should.equal(GleamBool)
+}
+
+pub fn map_bool_test() {
+  type_mapping.map_postgres_type("bool", "bool", False, [])
+  |> should.be_ok
+  |> should.equal(GleamBool)
+}
+
+// ============================================================================
+// BINARY TYPE MAPPING TESTS
+// ============================================================================
+
+pub fn map_bytea_test() {
+  type_mapping.map_postgres_type("bytea", "bytea", False, [])
+  |> should.be_ok
+  |> should.equal(GleamBitArray)
+}
+
+// ============================================================================
+// TIMESTAMP TYPE MAPPING TESTS
+// ============================================================================
+
+pub fn map_timestamp_test() {
+  type_mapping.map_postgres_type(
+    "timestamp without time zone",
+    "timestamp",
+    False,
+    [],
+  )
+  |> should.be_ok
+  |> should.equal(GleamTime)
+}
+
+pub fn map_timestamptz_test() {
+  type_mapping.map_postgres_type(
+    "timestamp with time zone",
+    "timestamptz",
+    False,
+    [],
+  )
+  |> should.be_ok
+  |> should.equal(GleamTime)
+}
+
+pub fn map_timestamp_short_test() {
+  type_mapping.map_postgres_type("timestamp", "timestamp", False, [])
+  |> should.be_ok
+  |> should.equal(GleamTime)
+}
+
+// ============================================================================
+// DATE TYPE MAPPING TESTS
+// ============================================================================
+
+pub fn map_date_test() {
+  type_mapping.map_postgres_type("date", "date", False, [])
+  |> should.be_ok
+  |> should.equal(GleamDate)
+}
+
+// ============================================================================
+// TIME TYPE MAPPING TESTS
+// ============================================================================
+
+pub fn map_time_test() {
+  type_mapping.map_postgres_type("time without time zone", "time", False, [])
+  |> should.be_ok
+  |> should.equal(GleamTimeOfDay)
+}
+
+pub fn map_timetz_test() {
+  type_mapping.map_postgres_type("time with time zone", "timetz", False, [])
+  |> should.be_ok
+  |> should.equal(GleamTimeOfDay)
+}
+
+pub fn map_time_short_test() {
+  type_mapping.map_postgres_type("time", "time", False, [])
+  |> should.be_ok
+  |> should.equal(GleamTimeOfDay)
+}
+
+// ============================================================================
+// UUID TYPE MAPPING TESTS
+// ============================================================================
+
+pub fn map_uuid_test() {
+  type_mapping.map_postgres_type("uuid", "uuid", False, [])
+  |> should.be_ok
+  |> should.equal(GleamUuid)
+}
+
+// ============================================================================
+// JSON TYPE MAPPING TESTS
+// ============================================================================
+
+pub fn map_json_test() {
+  type_mapping.map_postgres_type("json", "json", False, [])
+  |> should.be_ok
+  |> should.equal(GleamJson)
+}
+
+pub fn map_jsonb_test() {
+  type_mapping.map_postgres_type("jsonb", "jsonb", False, [])
+  |> should.be_ok
+  |> should.equal(GleamJson)
+}
+
+// ============================================================================
+// INTERVAL TYPE MAPPING TESTS
+// ============================================================================
+
+pub fn map_interval_test() {
+  type_mapping.map_postgres_type("interval", "interval", False, [])
+  |> should.be_ok
+  |> should.equal(GleamString)
+}
+
+// ============================================================================
+// NULLABLE TYPE TESTS
+// ============================================================================
+
+pub fn nullable_integer_test() {
+  type_mapping.map_postgres_type("integer", "int4", True, [])
+  |> should.be_ok
+  |> should.equal(GleamOption(GleamInt))
+}
+
+pub fn nullable_string_test() {
+  type_mapping.map_postgres_type("text", "text", True, [])
+  |> should.be_ok
+  |> should.equal(GleamOption(GleamString))
+}
+
+pub fn nullable_boolean_test() {
+  type_mapping.map_postgres_type("boolean", "bool", True, [])
+  |> should.be_ok
+  |> should.equal(GleamOption(GleamBool))
+}
+
+pub fn nullable_timestamp_test() {
+  type_mapping.map_postgres_type(
+    "timestamp with time zone",
+    "timestamptz",
+    True,
+    [],
+  )
+  |> should.be_ok
+  |> should.equal(GleamOption(GleamTime))
+}
+
+pub fn nullable_uuid_test() {
+  type_mapping.map_postgres_type("uuid", "uuid", True, [])
+  |> should.be_ok
+  |> should.equal(GleamOption(GleamUuid))
+}
+
+// ============================================================================
+// ARRAY TYPE TESTS
+// ============================================================================
+
+pub fn map_integer_array_test() {
+  type_mapping.map_postgres_type("array", "_int4", False, [])
+  |> should.be_ok
+  |> should.equal(GleamList(GleamInt))
+}
+
+pub fn map_text_array_test() {
+  type_mapping.map_postgres_type("array", "_text", False, [])
+  |> should.be_ok
+  |> should.equal(GleamList(GleamString))
+}
+
+pub fn map_varchar_array_test() {
+  type_mapping.map_postgres_type("array", "_varchar", False, [])
+  |> should.be_ok
+  |> should.equal(GleamList(GleamString))
+}
+
+pub fn map_boolean_array_test() {
+  type_mapping.map_postgres_type("array", "_bool", False, [])
+  |> should.be_ok
+  |> should.equal(GleamList(GleamBool))
+}
+
+pub fn map_uuid_array_test() {
+  type_mapping.map_postgres_type("array", "_uuid", False, [])
+  |> should.be_ok
+  |> should.equal(GleamList(GleamUuid))
+}
+
+pub fn map_float_array_test() {
+  type_mapping.map_postgres_type("array", "_float8", False, [])
+  |> should.be_ok
+  |> should.equal(GleamList(GleamFloat))
+}
+
+pub fn nullable_array_test() {
+  type_mapping.map_postgres_type("array", "_int4", True, [])
+  |> should.be_ok
+  |> should.equal(GleamOption(GleamList(GleamInt)))
+}
+
+pub fn map_enum_array_test() {
+  type_mapping.map_postgres_type("array", "_user_role", False, ["user_role"])
+  |> should.be_ok
+  |> should.equal(GleamList(GleamCustom("schema/enums", "UserRole")))
+}
+
+// ============================================================================
+// ENUM TYPE TESTS
+// ============================================================================
+
+pub fn map_enum_test() {
+  type_mapping.map_postgres_type("user-defined", "user_role", False, [
+    "user_role",
+  ])
+  |> should.be_ok
+  |> should.equal(GleamCustom("schema/enums", "UserRole"))
+}
+
+pub fn map_enum_nullable_test() {
+  type_mapping.map_postgres_type("user-defined", "user_status", True, [
+    "user_status",
+  ])
+  |> should.be_ok
+  |> should.equal(GleamOption(GleamCustom("schema/enums", "UserStatus")))
+}
+
+pub fn map_unknown_user_defined_test() {
+  // Unknown user-defined types are treated as custom types
+  type_mapping.map_postgres_type("user-defined", "my_custom_type", False, [])
+  |> should.be_ok
+  |> should.equal(GleamCustom("schema/types", "MyCustomType"))
+}
+
+// ============================================================================
+// ERROR HANDLING TESTS
+// ============================================================================
+
+pub fn unknown_type_error_test() {
+  type_mapping.map_postgres_type(
+    "unknown_postgres_type",
+    "unknown_udt",
+    False,
+    [],
+  )
+  |> should.be_error
+  |> should.equal(UnknownType("unknown", "unknown_udt"))
+}
+
+pub fn unsupported_array_error_test() {
+  // An array with a truly unknown element type
+  type_mapping.map_postgres_type("array", "_totally_unknown", False, [])
+  |> should.be_error
+  |> should.equal(UnsupportedArray("totally_unknown"))
+}
+
+// ============================================================================
+// COLUMN METADATA TESTS
+// ============================================================================
+
+pub fn map_column_basic_test() {
+  type_mapping.map_column("id", "integer", "int4", False, None, [])
+  |> should.be_ok
+  |> fn(meta: ColumnMeta) {
+    meta.gleam_type |> should.equal(GleamInt)
+    meta.is_auto_generated |> should.be_false
+    meta.column_name |> should.equal("id")
+    meta.is_nullable |> should.be_false
+  }
+}
+
+pub fn map_column_serial_auto_generated_test() {
+  type_mapping.map_column("id", "serial", "serial4", False, None, [])
+  |> should.be_ok
+  |> fn(meta: ColumnMeta) {
+    meta.gleam_type |> should.equal(GleamInt)
+    meta.is_auto_generated |> should.be_true
+  }
+}
+
+pub fn map_column_bigserial_auto_generated_test() {
+  type_mapping.map_column("id", "bigserial", "serial8", False, None, [])
+  |> should.be_ok
+  |> fn(meta: ColumnMeta) { meta.is_auto_generated |> should.be_true }
+}
+
+pub fn map_column_nextval_auto_generated_test() {
+  type_mapping.map_column(
+    "id",
+    "integer",
+    "int4",
+    False,
+    Some("nextval('users_id_seq'::regclass)"),
+    [],
+  )
+  |> should.be_ok
+  |> fn(meta: ColumnMeta) { meta.is_auto_generated |> should.be_true }
+}
+
+pub fn map_column_now_auto_generated_test() {
+  type_mapping.map_column(
+    "created_at",
+    "timestamp with time zone",
+    "timestamptz",
+    False,
+    Some("now()"),
+    [],
+  )
+  |> should.be_ok
+  |> fn(meta: ColumnMeta) { meta.is_auto_generated |> should.be_true }
+}
+
+pub fn map_column_current_timestamp_auto_generated_test() {
+  type_mapping.map_column(
+    "updated_at",
+    "timestamp with time zone",
+    "timestamptz",
+    True,
+    Some("CURRENT_TIMESTAMP"),
+    [],
+  )
+  |> should.be_ok
+  |> fn(meta: ColumnMeta) { meta.is_auto_generated |> should.be_true }
+}
+
+pub fn map_column_gen_random_uuid_auto_generated_test() {
+  type_mapping.map_column(
+    "uuid",
+    "uuid",
+    "uuid",
+    False,
+    Some("gen_random_uuid()"),
+    [],
+  )
+  |> should.be_ok
+  |> fn(meta: ColumnMeta) { meta.is_auto_generated |> should.be_true }
+}
+
+pub fn map_column_regular_default_not_auto_generated_test() {
+  type_mapping.map_column(
+    "status",
+    "text",
+    "text",
+    False,
+    Some("'pending'::text"),
+    [],
+  )
+  |> should.be_ok
+  |> fn(meta: ColumnMeta) {
+    // Regular defaults are NOT auto-generated
+    meta.is_auto_generated |> should.be_false
+  }
+}
+
+pub fn map_column_nullable_test() {
+  type_mapping.map_column("name", "text", "text", True, None, [])
+  |> should.be_ok
+  |> fn(meta: ColumnMeta) {
+    meta.gleam_type |> should.equal(GleamOption(GleamString))
+    meta.is_nullable |> should.be_true
+  }
+}
+
+pub fn map_column_with_enum_test() {
+  type_mapping.map_column("role", "user-defined", "user_role", False, None, [
+    "user_role",
+  ])
+  |> should.be_ok
+  |> fn(meta: ColumnMeta) {
+    meta.gleam_type
+    |> should.equal(GleamCustom("schema/enums", "UserRole"))
+  }
+}
+
+// ============================================================================
+// TYPE RENDERING TESTS
+// ============================================================================
+
+pub fn render_int_test() {
+  type_mapping.render_type(GleamInt)
+  |> should.equal("Int")
+}
+
+pub fn render_float_test() {
+  type_mapping.render_type(GleamFloat)
+  |> should.equal("Float")
+}
+
+pub fn render_string_test() {
+  type_mapping.render_type(GleamString)
+  |> should.equal("String")
+}
+
+pub fn render_bool_test() {
+  type_mapping.render_type(GleamBool)
+  |> should.equal("Bool")
+}
+
+pub fn render_bit_array_test() {
+  type_mapping.render_type(GleamBitArray)
+  |> should.equal("BitArray")
+}
+
+pub fn render_time_test() {
+  type_mapping.render_type(GleamTime)
+  |> should.equal("Time")
+}
+
+pub fn render_date_test() {
+  type_mapping.render_type(GleamDate)
+  |> should.equal("Date")
+}
+
+pub fn render_time_of_day_test() {
+  type_mapping.render_type(GleamTimeOfDay)
+  |> should.equal("TimeOfDay")
+}
+
+pub fn render_decimal_test() {
+  type_mapping.render_type(GleamDecimal)
+  |> should.equal("Decimal")
+}
+
+pub fn render_uuid_test() {
+  type_mapping.render_type(GleamUuid)
+  |> should.equal("Uuid")
+}
+
+pub fn render_json_test() {
+  type_mapping.render_type(GleamJson)
+  |> should.equal("Json")
+}
+
+pub fn render_list_test() {
+  type_mapping.render_type(GleamList(GleamInt))
+  |> should.equal("List(Int)")
+}
+
+pub fn render_option_test() {
+  type_mapping.render_type(GleamOption(GleamString))
+  |> should.equal("Option(String)")
+}
+
+pub fn render_custom_test() {
+  type_mapping.render_type(GleamCustom("schema/enums", "UserRole"))
+  |> should.equal("UserRole")
+}
+
+pub fn render_nested_option_list_test() {
+  type_mapping.render_type(GleamOption(GleamList(GleamInt)))
+  |> should.equal("Option(List(Int))")
+}
+
+// ============================================================================
+// QUALIFIED TYPE RENDERING TESTS
+// ============================================================================
+
+pub fn render_qualified_time_test() {
+  type_mapping.render_qualified_type(GleamTime)
+  |> should.equal("birl.Time")
+}
+
+pub fn render_qualified_decimal_test() {
+  type_mapping.render_qualified_type(GleamDecimal)
+  |> should.equal("decimal.Decimal")
+}
+
+pub fn render_qualified_uuid_test() {
+  type_mapping.render_qualified_type(GleamUuid)
+  |> should.equal("uuid.Uuid")
+}
+
+pub fn render_qualified_option_test() {
+  type_mapping.render_qualified_type(GleamOption(GleamString))
+  |> should.equal("option.Option(String)")
+}
+
+pub fn render_qualified_custom_test() {
+  type_mapping.render_qualified_type(GleamCustom("schema/enums", "UserRole"))
+  |> should.equal("schema/enums.UserRole")
+}
+
+// ============================================================================
+// IMPORTS COLLECTION TESTS
+// ============================================================================
+
+pub fn get_imports_basic_types_test() {
+  type_mapping.get_imports(GleamInt)
+  |> should.equal([])
+}
+
+pub fn get_imports_time_test() {
+  type_mapping.get_imports(GleamTime)
+  |> should.equal(["birl"])
+}
+
+pub fn get_imports_option_test() {
+  type_mapping.get_imports(GleamOption(GleamString))
+  |> should.equal(["gleam/option"])
+}
+
+pub fn get_imports_nested_test() {
+  type_mapping.get_imports(GleamOption(GleamTime))
+  |> should.equal(["gleam/option", "birl"])
+}
+
+pub fn collect_imports_test() {
+  let columns = [
+    ColumnMeta(
+      gleam_type: GleamInt,
+      is_auto_generated: False,
+      postgres_type: "integer",
+      udt_name: "int4",
+      column_name: "id",
+      is_nullable: False,
+    ),
+    ColumnMeta(
+      gleam_type: GleamOption(GleamTime),
+      is_auto_generated: True,
+      postgres_type: "timestamp with time zone",
+      udt_name: "timestamptz",
+      column_name: "created_at",
+      is_nullable: True,
+    ),
+    ColumnMeta(
+      gleam_type: GleamUuid,
+      is_auto_generated: False,
+      postgres_type: "uuid",
+      udt_name: "uuid",
+      column_name: "external_id",
+      is_nullable: False,
+    ),
+  ]
+
+  type_mapping.collect_imports(columns)
+  |> should.equal(["birl", "gleam/option", "uuid"])
+}
+
+// ============================================================================
+// UTILITY FUNCTION TESTS
+// ============================================================================
+
+pub fn pascal_case_simple_test() {
+  type_mapping.pascal_case("user")
+  |> should.equal("User")
+}
+
+pub fn pascal_case_snake_test() {
+  type_mapping.pascal_case("user_role")
+  |> should.equal("UserRole")
+}
+
+pub fn pascal_case_multiple_words_test() {
+  type_mapping.pascal_case("order_line_item")
+  |> should.equal("OrderLineItem")
+}
+
+pub fn pascal_case_empty_test() {
+  type_mapping.pascal_case("")
+  |> should.equal("")
+}
+
+pub fn snake_case_simple_test() {
+  type_mapping.snake_case("User")
+  |> should.equal("user")
+}
+
+pub fn snake_case_pascal_test() {
+  type_mapping.snake_case("UserRole")
+  |> should.equal("user_role")
+}
+
+pub fn snake_case_multiple_words_test() {
+  type_mapping.snake_case("OrderLineItem")
+  |> should.equal("order_line_item")
+}
+
+// ============================================================================
+// TYPE CHECKING FUNCTION TESTS
+// ============================================================================
+
+pub fn is_nullable_type_true_test() {
+  type_mapping.is_nullable_type(GleamOption(GleamString))
+  |> should.be_true
+}
+
+pub fn is_nullable_type_false_test() {
+  type_mapping.is_nullable_type(GleamString)
+  |> should.be_false
+}
+
+pub fn is_list_type_true_test() {
+  type_mapping.is_list_type(GleamList(GleamInt))
+  |> should.be_true
+}
+
+pub fn is_list_type_false_test() {
+  type_mapping.is_list_type(GleamInt)
+  |> should.be_false
+}
+
+pub fn is_custom_type_direct_test() {
+  type_mapping.is_custom_type(GleamCustom("schema/enums", "UserRole"))
+  |> should.be_true
+}
+
+pub fn is_custom_type_in_option_test() {
+  type_mapping.is_custom_type(
+    GleamOption(GleamCustom("schema/enums", "UserRole")),
+  )
+  |> should.be_true
+}
+
+pub fn is_custom_type_in_list_test() {
+  type_mapping.is_custom_type(
+    GleamList(GleamCustom("schema/enums", "UserRole")),
+  )
+  |> should.be_true
+}
+
+pub fn is_custom_type_false_test() {
+  type_mapping.is_custom_type(GleamString)
+  |> should.be_false
+}
+
+pub fn unwrap_option_test() {
+  type_mapping.unwrap_option(GleamOption(GleamString))
+  |> should.equal(GleamString)
+}
+
+pub fn unwrap_option_not_option_test() {
+  type_mapping.unwrap_option(GleamString)
+  |> should.equal(GleamString)
+}
+
+pub fn unwrap_list_test() {
+  type_mapping.unwrap_list(GleamList(GleamInt))
+  |> should.equal(GleamInt)
+}
+
+pub fn unwrap_list_not_list_test() {
+  type_mapping.unwrap_list(GleamInt)
+  |> should.equal(GleamInt)
+}
+
+pub fn types_equal_same_test() {
+  type_mapping.types_equal(GleamInt, GleamInt)
+  |> should.be_true
+}
+
+pub fn types_equal_different_test() {
+  type_mapping.types_equal(GleamInt, GleamString)
+  |> should.be_false
+}
+
+pub fn types_equal_list_test() {
+  type_mapping.types_equal(GleamList(GleamInt), GleamList(GleamInt))
+  |> should.be_true
+}
+
+pub fn types_equal_list_different_element_test() {
+  type_mapping.types_equal(GleamList(GleamInt), GleamList(GleamString))
+  |> should.be_false
+}
+
+pub fn types_equal_option_test() {
+  type_mapping.types_equal(GleamOption(GleamString), GleamOption(GleamString))
+  |> should.be_true
+}
+
+pub fn types_equal_custom_test() {
+  type_mapping.types_equal(
+    GleamCustom("schema/enums", "UserRole"),
+    GleamCustom("schema/enums", "UserRole"),
+  )
+  |> should.be_true
+}
+
+pub fn types_equal_custom_different_test() {
+  type_mapping.types_equal(
+    GleamCustom("schema/enums", "UserRole"),
+    GleamCustom("schema/enums", "UserStatus"),
+  )
+  |> should.be_false
+}
+
+// ============================================================================
+// UDT NAME FALLBACK TESTS
+// ============================================================================
+
+pub fn map_by_udt_name_int4_test() {
+  // When data_type is not recognized, fall back to udt_name
+  type_mapping.map_postgres_type("", "int4", False, [])
+  |> should.be_ok
+  |> should.equal(GleamInt)
+}
+
+pub fn map_by_udt_name_text_test() {
+  type_mapping.map_postgres_type("", "text", False, [])
+  |> should.be_ok
+  |> should.equal(GleamString)
+}
+
+pub fn map_by_udt_name_array_test() {
+  type_mapping.map_postgres_type("", "_int4", False, [])
+  |> should.be_ok
+  |> should.equal(GleamList(GleamInt))
+}
+
+pub fn map_by_udt_name_enum_test() {
+  type_mapping.map_postgres_type("", "user_role", False, ["user_role"])
+  |> should.be_ok
+  |> should.equal(GleamCustom("schema/enums", "UserRole"))
+}


### PR DESCRIPTION
## Summary
- Add comprehensive type mapping module (`src/cquill/codegen/type_mapping.gleam`) for code generation
- Convert PostgreSQL column types to appropriate Gleam types
- Support all common PostgreSQL types, nullable columns, arrays, and custom enums
- Detect auto-generated columns (serial, sequences, timestamps)
- 116 new tests covering all type mappings and utilities

## Features

### GleamType Enum
```gleam
pub type GleamType {
  GleamInt          // integer, smallint, bigint, serial, bigserial
  GleamFloat        // real, double precision
  GleamString       // varchar, char, text
  GleamBool         // boolean
  GleamBitArray     // bytea
  GleamTime         // timestamp with/without time zone
  GleamDate         // date
  GleamTimeOfDay    // time with/without time zone
  GleamDecimal      // numeric, decimal
  GleamUuid         // uuid
  GleamJson         // json, jsonb
  GleamList(GleamType)         // PostgreSQL arrays
  GleamOption(GleamType)       // Nullable columns
  GleamCustom(module, type_name)  // User-defined enums
}
```

### ColumnMeta for Extended Metadata
```gleam
pub type ColumnMeta {
  ColumnMeta(
    gleam_type: GleamType,
    is_auto_generated: Bool,  // serial, nextval(), now(), gen_random_uuid()
    postgres_type: String,
    udt_name: String,
    column_name: String,
    is_nullable: Bool,
  )
}
```

### Type Mapping Functions
- `map_postgres_type(data_type, udt_name, is_nullable, enum_names)` - Main mapping function
- `map_column(...)` - Full column metadata mapping
- `render_type(gleam_type)` - Render as Gleam type string
- `render_qualified_type(gleam_type)` - Render with module prefixes
- `get_imports(gleam_type)` - Get required imports
- `collect_imports(columns)` - Collect all imports for columns

### Auto-Generated Detection
Detects columns that should be excluded from insert types:
- Serial types (`serial`, `bigserial`, `smallserial`)
- Sequence defaults (`nextval('...')`)
- Timestamp defaults (`now()`, `CURRENT_TIMESTAMP`)
- UUID generation (`gen_random_uuid()`, `uuid_generate_v4()`)

## Test Plan
- [x] All standard PostgreSQL types map correctly
- [x] Nullable types wrapped in Option
- [x] Arrays map to List with correct element type
- [x] Custom enums detected and mapped
- [x] Unknown types produce clear errors
- [x] Serial types marked as auto-generated
- [x] Sequence defaults marked as auto-generated
- [x] Timestamp defaults marked as auto-generated
- [x] UUID generation marked as auto-generated
- [x] Regular defaults NOT marked as auto-generated
- [x] Type rendering produces valid Gleam code
- [x] Import collection works correctly
- [x] Utility functions (pascal_case, snake_case, etc.)

## Working Examples

```gleam
import cquill/codegen/type_mapping

// Map a simple integer column
type_mapping.map_postgres_type("integer", "int4", False, [])
// -> Ok(GleamInt)

// Map a nullable text column
type_mapping.map_postgres_type("text", "text", True, [])
// -> Ok(GleamOption(GleamString))

// Map an integer array
type_mapping.map_postgres_type("array", "_int4", False, [])
// -> Ok(GleamList(GleamInt))

// Map a custom enum
type_mapping.map_postgres_type("user-defined", "user_role", False, ["user_role"])
// -> Ok(GleamCustom("schema/enums", "UserRole"))

// Get full column metadata with auto-generation detection
type_mapping.map_column(
  "id",
  "serial",
  "serial4",
  False,
  None,
  [],
)
// -> Ok(ColumnMeta(
//      gleam_type: GleamInt,
//      is_auto_generated: True,  // Excluded from insert types
//      ...
//    ))

// Map a column with timestamp default
type_mapping.map_column(
  "created_at",
  "timestamp with time zone",
  "timestamptz",
  False,
  Some("now()"),
  [],
)
// -> Ok(ColumnMeta(
//      gleam_type: GleamTime,
//      is_auto_generated: True,  // now() detected as auto-generated
//      ...
//    ))

// Render types for code generation
type_mapping.render_type(GleamOption(GleamList(GleamInt)))
// -> "Option(List(Int))"

type_mapping.render_qualified_type(GleamTime)
// -> "birl.Time"

// Collect imports for columns
let columns = [
  ColumnMeta(gleam_type: GleamOption(GleamTime), ...),
  ColumnMeta(gleam_type: GleamUuid, ...),
]
type_mapping.collect_imports(columns)
// -> ["birl", "gleam/option", "uuid"]
```

## Type Mapping Table

| PostgreSQL Type | Gleam Type | Notes |
|----------------|------------|-------|
| `integer`, `int4` | `Int` | |
| `smallint`, `int2` | `Int` | |
| `bigint`, `int8` | `Int` | |
| `serial`, `bigserial` | `Int` | Auto-generated |
| `real`, `float4` | `Float` | |
| `double precision`, `float8` | `Float` | |
| `numeric`, `decimal` | `Decimal` | External package |
| `character varying`, `varchar` | `String` | |
| `character`, `char`, `bpchar` | `String` | |
| `text` | `String` | |
| `boolean`, `bool` | `Bool` | |
| `bytea` | `BitArray` | |
| `timestamp`, `timestamptz` | `Time` | Uses birl |
| `date` | `Date` | Uses birl |
| `time`, `timetz` | `TimeOfDay` | Uses birl |
| `uuid` | `Uuid` | External package |
| `json`, `jsonb` | `Json` | |
| `ARRAY` (`_*`) | `List(T)` | Recursive element type |
| User enum | `GleamCustom` | PascalCase type name |
| Nullable | `Option(T)` | Wraps inner type |

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)