### PR TITLE
Implement type-safe condition builders for phantom-typed queries

### DIFF
--- a/src/cquill/query.gleam
+++ b/src/cquill/query.gleam
@@ -17,9 +17,9 @@ import cquill/query/ast.{
   type Condition, type Direction, type Join, type JoinType, type NullsOrder,
   type OrderBy, type Query, type Select, type SelectExpression, type Source,
   type Value, type Where, And, Asc, Between, BoolValue, CrossJoin, Desc, Eq,
-  FloatValue, FullJoin, Gt, Gte, In, InnerJoin, IntValue, IsNotNull, IsNull,
-  Join as JoinClause, LeftJoin, Like, ListValue, Lt, Lte, Not, NotEq, NotIn,
-  NotLike, NullValue, NullsDefault, NullsFirst, NullsLast, Or,
+  FloatValue, FullJoin, Gt, Gte, ILike, In, InnerJoin, IntValue, IsNotNull,
+  IsNull, Join as JoinClause, LeftJoin, Like, ListValue, Lt, Lte, Not, NotEq,
+  NotILike, NotIn, NotLike, NullValue, NullsDefault, NullsFirst, NullsLast, Or,
   OrderBy as OrderByClause, Query as QueryRecord, Raw, RightJoin, SelectAll,
   SelectExpr, SelectFields, StringValue, SubquerySource, TableSource,
   Where as WhereClause,
@@ -760,6 +760,8 @@ fn condition_to_string(cond: Condition) -> String {
       <> ")"
     Like(field, pattern) -> field <> " LIKE '" <> pattern <> "'"
     NotLike(field, pattern) -> field <> " NOT LIKE '" <> pattern <> "'"
+    ILike(field, pattern) -> field <> " ILIKE '" <> pattern <> "'"
+    NotILike(field, pattern) -> field <> " NOT ILIKE '" <> pattern <> "'"
     IsNull(field) -> field <> " IS NULL"
     IsNotNull(field) -> field <> " IS NOT NULL"
     Between(field, low, high) ->

--- a/src/cquill/query/ast.gleam
+++ b/src/cquill/query/ast.gleam
@@ -141,6 +141,10 @@ pub type Condition {
   Like(field: String, pattern: String)
   /// field NOT LIKE pattern
   NotLike(field: String, pattern: String)
+  /// field ILIKE pattern (case-insensitive LIKE)
+  ILike(field: String, pattern: String)
+  /// field NOT ILIKE pattern
+  NotILike(field: String, pattern: String)
   /// field IS NULL
   IsNull(field: String)
   /// field IS NOT NULL

--- a/src/cquill/query/builder.gleam
+++ b/src/cquill/query/builder.gleam
@@ -363,6 +363,8 @@ fn extract_fields_from_condition(condition: Condition) -> List(String) {
     ast.NotIn(field, _) -> [field]
     ast.Like(field, _) -> [field]
     ast.NotLike(field, _) -> [field]
+    ast.ILike(field, _) -> [field]
+    ast.NotILike(field, _) -> [field]
     ast.IsNull(field) -> [field]
     ast.IsNotNull(field) -> [field]
     ast.Between(field, _, _) -> [field]


### PR DESCRIPTION
## Summary
- Implements type-safe condition builders with phantom type enforcement as specified in Issue #25
- Adds string helper conditions (ilike, starts_with, ends_with, contains)
- Adds cross-table column comparison functions with Join2 scope type safety

## Changes
- Add `ILike` and `NotILike` conditions to `src/cquill/query/ast.gleam` for case-insensitive LIKE matching
- Add typed condition builders to `src/cquill/typed/query.gleam`:
  - `typed_ilike`/`typed_not_ilike` - Case-insensitive pattern matching
  - `typed_starts_with` - Prefix matching (generates `LIKE 'prefix%'`)
  - `typed_ends_with` - Suffix matching (generates `LIKE '%suffix'`)
  - `typed_contains` - Substring matching (generates `LIKE '%substring%'`)
  - `typed_eq_columns`/`typed_not_eq_columns`/`typed_gt_columns`/`typed_lt_columns`/`typed_gte_columns`/`typed_lte_columns` - Cross-table column comparison with `Join2(t1, t2)` scope
  - `typed_column_gte`/`typed_column_lte` - Same-table column comparisons
- Update SQL compiler in `src/cquill/query.gleam` to render `ILIKE` and `NOT ILIKE`
- Update `extract_fields_from_condition` in `src/cquill/query/builder.gleam`
- Add comprehensive tests in `test/cquill/typed/query_test.gleam`

## Test Plan
- [x] All 700 existing tests pass (`gleam test`)
- [x] New tests added for all new condition builders
- [x] Code is formatted (`gleam format --check src test`)

## Working Examples

### String Condition Builders
```gleam
import cquill/typed/query.{typed_from, typed_where, typed_ilike, typed_starts_with, typed_ends_with, typed_contains}
import cquill/typed/table.{type Column, type Table, table, column}

// Define phantom types and table/column factories
type UserTable
fn users() -> Table(UserTable) { table("users") }
fn email() -> Column(UserTable, String) { column("email") }

// Case-insensitive pattern matching
typed_from(users())
|> typed_where(typed_ilike(email(), "%@EXAMPLE.COM"))  // ILIKE for case-insensitive

// Convenience string helpers
typed_from(users())
|> typed_where(typed_starts_with(email(), "admin"))      // LIKE 'admin%'
|> typed_where(typed_ends_with(email(), "@example.com")) // LIKE '%@example.com'
|> typed_where(typed_contains(email(), "support"))       // LIKE '%support%'
```

### Cross-Table Column Comparison
```gleam
import cquill/typed/query.{typed_from, typed_join, typed_eq_columns}
import cquill/typed/table.{type Column, type Join2, type Table, table, column}

// Define phantom types
type UserTable
type PostTable

// Table factories
fn users() -> Table(UserTable) { table("users") }
fn posts() -> Table(PostTable) { table("posts") }

// Column factories
fn user_id() -> Column(UserTable, Int) { column("id") }
fn post_user_id() -> Column(PostTable, Int) { column("user_id") }

// Cross-table join condition with type-safe Join2 scope
let join_condition: query.TypedCondition(Join2(UserTable, PostTable)) =
  typed_eq_columns(user_id(), post_user_id())

typed_from(users())
|> typed_join(posts(), on: join_condition)
// Type system ensures columns from different tables produce Join2 scope
```

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)