### PR TITLE
Implement raw SQL escape hatch for typed queries

### DIFF
--- a/src/cquill/typed/raw.gleam
+++ b/src/cquill/typed/raw.gleam
@@ -1,0 +1,632 @@
+// cquill Raw SQL Escape Hatch
+//
+// This module provides escape hatches for raw SQL when the query builder
+// can't express something. Use with caution as raw SQL bypasses type checking.
+//
+// WARNING: Raw SQL bypasses compile-time type checking.
+// Ensure your SQL is valid and properly parameterized to prevent SQL injection.
+//
+// ## Safe Usage (with parameters):
+// ```gleam
+// raw_with_params("email = $1", [StringValue(user_input)])
+// ```
+//
+// ## Unsafe Usage (DO NOT DO THIS):
+// ```gleam
+// // SQL injection risk!
+// raw("email = '" <> user_input <> "'")
+// ```
+
+import cquill/query/ast
+import cquill/typed/table.{type Column, column_name}
+import gleam/list
+import gleam/option.{type Option, None, Some}
+
+// ============================================================================
+// RAW EXPRESSION TYPE
+// ============================================================================
+
+/// A raw SQL expression with optional parameters.
+///
+/// WARNING: Raw SQL bypasses compile-time type checking.
+/// Ensure your SQL is valid and properly parameterized.
+///
+/// ## Example
+/// ```gleam
+/// raw("NOW()")
+/// raw_with_params("created_at > $1", [StringValue("2024-01-01")])
+/// ```
+pub opaque type RawExpr {
+  RawExpr(sql: String, params: List(ast.Value))
+}
+
+/// Create a raw SQL expression without parameters.
+///
+/// WARNING: This bypasses type safety. Use for database functions
+/// and expressions that don't accept user input.
+///
+/// ## Example
+/// ```gleam
+/// raw("NOW()")
+/// raw("RANDOM()")
+/// ```
+pub fn raw(sql: String) -> RawExpr {
+  RawExpr(sql: sql, params: [])
+}
+
+/// Create a raw SQL expression with parameters.
+/// Always prefer this over string concatenation to prevent SQL injection.
+///
+/// ## Example
+/// ```gleam
+/// raw_with_params("email = $1", [StringValue(user_input)])
+/// raw_with_params("created_at > $1 AND status = $2", [
+///   StringValue("2024-01-01"),
+///   StringValue("active"),
+/// ])
+/// ```
+pub fn raw_with_params(sql: String, params: List(ast.Value)) -> RawExpr {
+  RawExpr(sql: sql, params: params)
+}
+
+/// Extract the SQL string from a RawExpr.
+pub fn raw_sql(expr: RawExpr) -> String {
+  let RawExpr(sql: sql, params: _) = expr
+  sql
+}
+
+/// Extract the parameters from a RawExpr.
+pub fn raw_params(expr: RawExpr) -> List(ast.Value) {
+  let RawExpr(sql: _, params: params) = expr
+  params
+}
+
+/// Convert a RawExpr to an AST Condition for use in WHERE clauses.
+pub fn raw_to_condition(expr: RawExpr) -> ast.Condition {
+  let RawExpr(sql: sql, params: params) = expr
+  ast.Raw(sql: sql, params: params)
+}
+
+/// Convert a RawExpr to an AST SelectExpression for use in SELECT clauses.
+pub fn raw_to_select_expr(
+  expr: RawExpr,
+  alias: Option(String),
+) -> ast.SelectExpression {
+  let RawExpr(sql: sql, params: _) = expr
+  // For select expressions, we embed the SQL as a function expression
+  // The compiler will handle rendering this appropriately
+  ast.SelectExpression(
+    expr: ast.FunctionExpr(name: sql, args: []),
+    alias: alias,
+  )
+}
+
+/// Convert a RawExpr to an AST OrderBy for use in ORDER BY clauses.
+pub fn raw_to_order_by(expr: RawExpr, direction: ast.Direction) -> ast.OrderBy {
+  let RawExpr(sql: sql, params: _) = expr
+  ast.OrderBy(field: sql, direction: direction, nulls: ast.NullsDefault)
+}
+
+// ============================================================================
+// FRAGMENT HELPERS - Common SQL patterns
+// ============================================================================
+
+/// NOW() - Current timestamp
+///
+/// ## Example
+/// ```gleam
+/// select_raw(query, [now()])
+/// where_raw(query, raw_with_params("created_at > $1 - $2", [
+///   now_as_value(),
+///   interval(7, "days"),
+/// ]))
+/// ```
+pub fn now() -> RawExpr {
+  raw("NOW()")
+}
+
+/// CURRENT_TIMESTAMP - Current timestamp (alternative to NOW())
+pub fn current_timestamp() -> RawExpr {
+  raw("CURRENT_TIMESTAMP")
+}
+
+/// CURRENT_DATE - Current date without time
+pub fn current_date() -> RawExpr {
+  raw("CURRENT_DATE")
+}
+
+/// CURRENT_TIME - Current time without date
+pub fn current_time() -> RawExpr {
+  raw("CURRENT_TIME")
+}
+
+/// Generate an INTERVAL expression.
+///
+/// ## Example
+/// ```gleam
+/// interval(7, "days")   // INTERVAL '7 days'
+/// interval(1, "hour")   // INTERVAL '1 hour'
+/// interval(30, "minutes")  // INTERVAL '30 minutes'
+/// ```
+pub fn interval(amount: Int, unit: String) -> RawExpr {
+  raw("INTERVAL '" <> int_to_string(amount) <> " " <> unit <> "'")
+}
+
+/// COALESCE - Return first non-null value.
+/// Uses column name for type safety reference.
+///
+/// ## Example
+/// ```gleam
+/// coalesce_column(user_nickname, "Anonymous")
+/// // COALESCE(nickname, 'Anonymous')
+/// ```
+pub fn coalesce_column(
+  column: Column(t, Option(String)),
+  default: String,
+) -> RawExpr {
+  raw(
+    "COALESCE("
+    <> column_name(column)
+    <> ", '"
+    <> escape_string(default)
+    <> "')",
+  )
+}
+
+/// COALESCE for integer columns.
+pub fn coalesce_int_column(
+  column: Column(t, Option(Int)),
+  default: Int,
+) -> RawExpr {
+  raw(
+    "COALESCE(" <> column_name(column) <> ", " <> int_to_string(default) <> ")",
+  )
+}
+
+/// COALESCE with raw expressions.
+///
+/// ## Example
+/// ```gleam
+/// coalesce_raw([raw("nickname"), raw("'Anonymous'")])
+/// ```
+pub fn coalesce_raw(expressions: List(RawExpr)) -> RawExpr {
+  let sqls = list.map(expressions, raw_sql)
+  raw("COALESCE(" <> join_with_comma(sqls) <> ")")
+}
+
+/// NULLIF - Return NULL if two expressions are equal.
+///
+/// ## Example
+/// ```gleam
+/// nullif_column(status, "deleted")
+/// // NULLIF(status, 'deleted')
+/// ```
+pub fn nullif_column(column: Column(t, String), value: String) -> RawExpr {
+  raw("NULLIF(" <> column_name(column) <> ", '" <> escape_string(value) <> "')")
+}
+
+/// CAST - Cast an expression to a different type.
+///
+/// ## Example
+/// ```gleam
+/// cast(raw("'123'"), "INTEGER")  // CAST('123' AS INTEGER)
+/// cast(raw("created_at"), "DATE")  // CAST(created_at AS DATE)
+/// ```
+pub fn cast(expr: RawExpr, to_type: String) -> RawExpr {
+  raw("CAST(" <> raw_sql(expr) <> " AS " <> to_type <> ")")
+}
+
+/// CAST a column to a different type.
+pub fn cast_column(column: Column(t, a), to_type: String) -> RawExpr {
+  raw("CAST(" <> column_name(column) <> " AS " <> to_type <> ")")
+}
+
+/// RANDOM() - Generate a random value (useful for random ordering).
+///
+/// ## Example
+/// ```gleam
+/// order_by_raw(query, random(), Asc)  // Random order
+/// ```
+pub fn random() -> RawExpr {
+  raw("RANDOM()")
+}
+
+/// COUNT(*) - Count all rows.
+pub fn count_all() -> RawExpr {
+  raw("COUNT(*)")
+}
+
+/// COUNT(column) - Count non-null values in a column.
+pub fn count_column(column: Column(t, a)) -> RawExpr {
+  raw("COUNT(" <> column_name(column) <> ")")
+}
+
+/// COUNT(DISTINCT column) - Count distinct non-null values.
+pub fn count_distinct(column: Column(t, a)) -> RawExpr {
+  raw("COUNT(DISTINCT " <> column_name(column) <> ")")
+}
+
+/// SUM(column) - Sum values in a column.
+pub fn sum(column: Column(t, a)) -> RawExpr {
+  raw("SUM(" <> column_name(column) <> ")")
+}
+
+/// AVG(column) - Average values in a column.
+pub fn avg(column: Column(t, a)) -> RawExpr {
+  raw("AVG(" <> column_name(column) <> ")")
+}
+
+/// MIN(column) - Minimum value in a column.
+pub fn min(column: Column(t, a)) -> RawExpr {
+  raw("MIN(" <> column_name(column) <> ")")
+}
+
+/// MAX(column) - Maximum value in a column.
+pub fn max(column: Column(t, a)) -> RawExpr {
+  raw("MAX(" <> column_name(column) <> ")")
+}
+
+/// COUNT(*) OVER () - Window function for total count.
+/// Useful for pagination to get total count alongside results.
+///
+/// ## Example
+/// ```gleam
+/// select_raw(query, [count_over_with_alias("total_count")])
+/// ```
+pub fn count_over() -> RawExpr {
+  raw("COUNT(*) OVER ()")
+}
+
+/// COUNT(*) OVER () with an alias.
+pub fn count_over_with_alias(alias: String) -> RawExpr {
+  raw("COUNT(*) OVER () AS " <> alias)
+}
+
+/// ROW_NUMBER() OVER (ORDER BY column).
+pub fn row_number_over(
+  column: Column(t, a),
+  direction: ast.Direction,
+) -> RawExpr {
+  let dir_str = case direction {
+    ast.Asc -> "ASC"
+    ast.Desc -> "DESC"
+  }
+  raw(
+    "ROW_NUMBER() OVER (ORDER BY "
+    <> column_name(column)
+    <> " "
+    <> dir_str
+    <> ")",
+  )
+}
+
+/// LOWER(column) - Lowercase string.
+pub fn lower(column: Column(t, String)) -> RawExpr {
+  raw("LOWER(" <> column_name(column) <> ")")
+}
+
+/// UPPER(column) - Uppercase string.
+pub fn upper(column: Column(t, String)) -> RawExpr {
+  raw("UPPER(" <> column_name(column) <> ")")
+}
+
+/// TRIM(column) - Remove leading/trailing whitespace.
+pub fn trim(column: Column(t, String)) -> RawExpr {
+  raw("TRIM(" <> column_name(column) <> ")")
+}
+
+/// LENGTH(column) - String length.
+pub fn length(column: Column(t, String)) -> RawExpr {
+  raw("LENGTH(" <> column_name(column) <> ")")
+}
+
+/// CONCAT - Concatenate multiple expressions.
+///
+/// ## Example
+/// ```gleam
+/// concat([raw("first_name"), raw("' '"), raw("last_name")])
+/// ```
+pub fn concat(expressions: List(RawExpr)) -> RawExpr {
+  let sqls = list.map(expressions, raw_sql)
+  raw("CONCAT(" <> join_with_comma(sqls) <> ")")
+}
+
+/// Concatenate columns with a separator.
+///
+/// ## Example
+/// ```gleam
+/// concat_columns_with_separator([first_name, last_name], " ")
+/// // first_name || ' ' || last_name
+/// ```
+pub fn concat_columns_with_separator(
+  columns: List(Column(t, String)),
+  separator: String,
+) -> RawExpr {
+  let names = list.map(columns, column_name)
+  let joined = join_with(names, " || '" <> escape_string(separator) <> "' || ")
+  raw(joined)
+}
+
+/// EXTRACT(field FROM column) - Extract part of a timestamp.
+///
+/// ## Example
+/// ```gleam
+/// extract("year", created_at)   // EXTRACT(year FROM created_at)
+/// extract("month", created_at)  // EXTRACT(month FROM created_at)
+/// ```
+pub fn extract(field: String, column: Column(t, a)) -> RawExpr {
+  raw("EXTRACT(" <> field <> " FROM " <> column_name(column) <> ")")
+}
+
+/// DATE_TRUNC - Truncate timestamp to specified precision.
+///
+/// ## Example
+/// ```gleam
+/// date_trunc("month", created_at)  // DATE_TRUNC('month', created_at)
+/// ```
+pub fn date_trunc(precision: String, column: Column(t, a)) -> RawExpr {
+  raw("DATE_TRUNC('" <> precision <> "', " <> column_name(column) <> ")")
+}
+
+/// AGE - Calculate age between timestamps.
+///
+/// ## Example
+/// ```gleam
+/// age_from_now(birth_date)  // AGE(birth_date)
+/// ```
+pub fn age_from_now(column: Column(t, a)) -> RawExpr {
+  raw("AGE(" <> column_name(column) <> ")")
+}
+
+/// Generate a CASE expression.
+///
+/// ## Example
+/// ```gleam
+/// case_when([
+///   #(raw("status = 'active'"), raw("'Active'")),
+///   #(raw("status = 'pending'"), raw("'Pending'")),
+/// ], raw("'Unknown'"))
+/// ```
+pub fn case_when(
+  conditions: List(#(RawExpr, RawExpr)),
+  else_expr: RawExpr,
+) -> RawExpr {
+  let when_clauses =
+    list.map(conditions, fn(pair) {
+      let #(condition, result) = pair
+      "WHEN " <> raw_sql(condition) <> " THEN " <> raw_sql(result)
+    })
+  let sql =
+    "CASE "
+    <> join_with_space(when_clauses)
+    <> " ELSE "
+    <> raw_sql(else_expr)
+    <> " END"
+  raw(sql)
+}
+
+/// EXISTS subquery check.
+///
+/// ## Example
+/// ```gleam
+/// exists(raw("SELECT 1 FROM orders WHERE orders.user_id = users.id"))
+/// ```
+pub fn exists(subquery: RawExpr) -> RawExpr {
+  raw("EXISTS (" <> raw_sql(subquery) <> ")")
+}
+
+/// NOT EXISTS subquery check.
+pub fn not_exists(subquery: RawExpr) -> RawExpr {
+  raw("NOT EXISTS (" <> raw_sql(subquery) <> ")")
+}
+
+/// IN with a subquery.
+///
+/// ## Example
+/// ```gleam
+/// in_subquery(user_id, raw("SELECT id FROM active_users"))
+/// ```
+pub fn in_subquery(column: Column(t, a), subquery: RawExpr) -> RawExpr {
+  raw(column_name(column) <> " IN (" <> raw_sql(subquery) <> ")")
+}
+
+/// NOT IN with a subquery.
+pub fn not_in_subquery(column: Column(t, a), subquery: RawExpr) -> RawExpr {
+  raw(column_name(column) <> " NOT IN (" <> raw_sql(subquery) <> ")")
+}
+
+// ============================================================================
+// COMPARISON HELPERS
+// ============================================================================
+
+/// Create a raw comparison between a column and a raw expression.
+///
+/// ## Example
+/// ```gleam
+/// column_raw_eq(created_at, now())
+/// // created_at = NOW()
+/// ```
+pub fn column_raw_eq(column: Column(t, a), expr: RawExpr) -> RawExpr {
+  raw(column_name(column) <> " = " <> raw_sql(expr))
+}
+
+/// Column greater than raw expression.
+pub fn column_raw_gt(column: Column(t, a), expr: RawExpr) -> RawExpr {
+  raw(column_name(column) <> " > " <> raw_sql(expr))
+}
+
+/// Column greater than or equal to raw expression.
+pub fn column_raw_gte(column: Column(t, a), expr: RawExpr) -> RawExpr {
+  raw(column_name(column) <> " >= " <> raw_sql(expr))
+}
+
+/// Column less than raw expression.
+pub fn column_raw_lt(column: Column(t, a), expr: RawExpr) -> RawExpr {
+  raw(column_name(column) <> " < " <> raw_sql(expr))
+}
+
+/// Column less than or equal to raw expression.
+pub fn column_raw_lte(column: Column(t, a), expr: RawExpr) -> RawExpr {
+  raw(column_name(column) <> " <= " <> raw_sql(expr))
+}
+
+/// Column between two raw expressions.
+pub fn column_raw_between(
+  column: Column(t, a),
+  low: RawExpr,
+  high: RawExpr,
+) -> RawExpr {
+  raw(
+    column_name(column)
+    <> " BETWEEN "
+    <> raw_sql(low)
+    <> " AND "
+    <> raw_sql(high),
+  )
+}
+
+// ============================================================================
+// ARITHMETIC HELPERS
+// ============================================================================
+
+/// Add two raw expressions.
+pub fn add(left: RawExpr, right: RawExpr) -> RawExpr {
+  raw("(" <> raw_sql(left) <> " + " <> raw_sql(right) <> ")")
+}
+
+/// Subtract right from left.
+pub fn subtract(left: RawExpr, right: RawExpr) -> RawExpr {
+  raw("(" <> raw_sql(left) <> " - " <> raw_sql(right) <> ")")
+}
+
+/// Multiply two expressions.
+pub fn multiply(left: RawExpr, right: RawExpr) -> RawExpr {
+  raw("(" <> raw_sql(left) <> " * " <> raw_sql(right) <> ")")
+}
+
+/// Divide left by right.
+pub fn divide(left: RawExpr, right: RawExpr) -> RawExpr {
+  raw("(" <> raw_sql(left) <> " / " <> raw_sql(right) <> ")")
+}
+
+/// Modulo operation.
+pub fn modulo(left: RawExpr, right: RawExpr) -> RawExpr {
+  raw("(" <> raw_sql(left) <> " % " <> raw_sql(right) <> ")")
+}
+
+/// Create a raw expression from a column name.
+pub fn column_expr(column: Column(t, a)) -> RawExpr {
+  raw(column_name(column))
+}
+
+/// Create a raw expression from a literal integer.
+pub fn int_literal(value: Int) -> RawExpr {
+  raw(int_to_string(value))
+}
+
+/// Create a raw expression from a literal float.
+pub fn float_literal(value: Float) -> RawExpr {
+  raw(float_to_string(value))
+}
+
+/// Create a raw expression from a literal string.
+/// The string is properly escaped and quoted.
+pub fn string_literal(value: String) -> RawExpr {
+  raw("'" <> escape_string(value) <> "'")
+}
+
+/// Create a raw expression for boolean TRUE.
+pub fn true_literal() -> RawExpr {
+  raw("TRUE")
+}
+
+/// Create a raw expression for boolean FALSE.
+pub fn false_literal() -> RawExpr {
+  raw("FALSE")
+}
+
+/// Create a raw expression for NULL.
+pub fn null_literal() -> RawExpr {
+  raw("NULL")
+}
+
+// ============================================================================
+// LOGICAL OPERATORS
+// ============================================================================
+
+/// AND multiple raw conditions.
+pub fn and_raw(conditions: List(RawExpr)) -> RawExpr {
+  let sqls = list.map(conditions, raw_sql)
+  raw("(" <> join_with(sqls, " AND ") <> ")")
+}
+
+/// OR multiple raw conditions.
+pub fn or_raw(conditions: List(RawExpr)) -> RawExpr {
+  let sqls = list.map(conditions, raw_sql)
+  raw("(" <> join_with(sqls, " OR ") <> ")")
+}
+
+/// NOT a raw condition.
+pub fn not_raw(condition: RawExpr) -> RawExpr {
+  raw("NOT (" <> raw_sql(condition) <> ")")
+}
+
+// ============================================================================
+// HELPER FUNCTIONS (INTERNAL)
+// ============================================================================
+
+fn int_to_string(i: Int) -> String {
+  case i < 0 {
+    True -> "-" <> positive_int_to_string(-i)
+    False -> positive_int_to_string(i)
+  }
+}
+
+fn positive_int_to_string(i: Int) -> String {
+  case i {
+    0 -> "0"
+    1 -> "1"
+    2 -> "2"
+    3 -> "3"
+    4 -> "4"
+    5 -> "5"
+    6 -> "6"
+    7 -> "7"
+    8 -> "8"
+    9 -> "9"
+    _ -> positive_int_to_string(i / 10) <> positive_int_to_string(i % 10)
+  }
+}
+
+fn float_to_string(f: Float) -> String {
+  do_float_to_string(f)
+}
+
+@external(erlang, "erlang", "float_to_binary")
+@external(javascript, "../../../cquill_ffi.mjs", "float_to_string")
+fn do_float_to_string(f: Float) -> String
+
+fn escape_string(s: String) -> String {
+  // Basic SQL string escaping - replace single quotes with two single quotes
+  do_escape_string(s)
+}
+
+@external(erlang, "cquill_ffi", "escape_sql_string")
+@external(javascript, "../../../cquill_ffi.mjs", "escape_sql_string")
+fn do_escape_string(s: String) -> String
+
+fn join_with_comma(strings: List(String)) -> String {
+  join_with(strings, ", ")
+}
+
+fn join_with_space(strings: List(String)) -> String {
+  join_with(strings, " ")
+}
+
+fn join_with(strings: List(String), separator: String) -> String {
+  case strings {
+    [] -> ""
+    [first] -> first
+    [first, ..rest] -> first <> separator <> join_with(rest, separator)
+  }
+}

--- a/src/cquill_ffi.erl
+++ b/src/cquill_ffi.erl
@@ -1,5 +1,5 @@
 -module(cquill_ffi).
--export([coerce_value/1]).
+-export([coerce_value/1, escape_sql_string/1]).
 
 %% Coerce a Gleam value to a tagged union for type detection
 %% This allows the query builder to create the appropriate Value type
@@ -21,3 +21,7 @@ coerce_value(Value) when is_list(Value) ->
     {list_val, [coerce_value(V) || V <- Value]};
 coerce_value(_) ->
     unknown_val.
+
+%% Escape single quotes in SQL strings by doubling them
+escape_sql_string(String) when is_binary(String) ->
+    binary:replace(String, <<"'">>, <<"''">>, [global]).

--- a/src/cquill_ffi.mjs
+++ b/src/cquill_ffi.mjs
@@ -33,3 +33,13 @@ export function coerce_value(value) {
 
   return { type: 'UnknownVal' };
 }
+
+// Escape single quotes in SQL strings by doubling them
+export function escape_sql_string(str) {
+  return str.replace(/'/g, "''");
+}
+
+// Convert float to string
+export function float_to_string(f) {
+  return String(f);
+}

--- a/test/cquill/typed/raw_query_test.gleam
+++ b/test/cquill/typed/raw_query_test.gleam
@@ -1,0 +1,393 @@
+// Raw SQL in Typed Query Tests
+//
+// Tests for using raw SQL expressions within typed queries.
+// These tests verify the integration between the raw module
+// and the typed query builder.
+
+import cquill/query/ast
+import cquill/typed/query.{
+  to_ast, typed_from, typed_group_by_raw, typed_having_raw, typed_order_by_raw,
+  typed_raw_condition, typed_select_raw, typed_select_raw_aliased, typed_where,
+  typed_where_raw,
+}
+import cquill/typed/raw.{
+  column_raw_gt, count_all, count_over_with_alias, date_trunc, interval, now,
+  random, raw, subtract,
+}
+import cquill/typed/table.{type Column, type Table, column, table}
+import gleam/list
+import gleam/option.{None, Some}
+import gleeunit/should
+
+// ============================================================================
+// MOCK TABLE TYPES
+// ============================================================================
+
+/// Phantom type for the users table
+pub type UserTable
+
+/// Phantom type for the orders table
+pub type OrderTable
+
+// Mock table factories
+fn users() -> Table(UserTable) {
+  table("users")
+}
+
+fn orders() -> Table(OrderTable) {
+  table("orders")
+}
+
+// Mock column factories
+fn user_id() -> Column(UserTable, Int) {
+  column("id")
+}
+
+fn user_active() -> Column(UserTable, Bool) {
+  column("active")
+}
+
+fn user_created_at() -> Column(UserTable, String) {
+  column("created_at")
+}
+
+fn order_user_id() -> Column(OrderTable, Int) {
+  column("user_id")
+}
+
+fn order_created_at() -> Column(OrderTable, String) {
+  column("created_at")
+}
+
+// ============================================================================
+// TYPED_WHERE_RAW TESTS
+// ============================================================================
+
+pub fn typed_where_raw_adds_condition_test() {
+  let query =
+    typed_from(users())
+    |> typed_where_raw(raw("created_at > NOW() - INTERVAL '7 days'"))
+
+  let ast_query = to_ast(query)
+  list.length(ast_query.wheres) |> should.equal(1)
+
+  case ast_query.wheres {
+    [ast.Where(condition)] -> {
+      case condition {
+        ast.Raw(sql, _) -> {
+          sql |> should.equal("created_at > NOW() - INTERVAL '7 days'")
+        }
+        _ -> should.fail()
+      }
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn typed_where_raw_with_params_test() {
+  let query =
+    typed_from(users())
+    |> typed_where_raw(
+      raw.raw_with_params("email = $1", [ast.StringValue("test@example.com")]),
+    )
+
+  let ast_query = to_ast(query)
+  case ast_query.wheres {
+    [ast.Where(condition)] -> {
+      case condition {
+        ast.Raw(sql, params) -> {
+          sql |> should.equal("email = $1")
+          params |> should.equal([ast.StringValue("test@example.com")])
+        }
+        _ -> should.fail()
+      }
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn mixed_typed_and_raw_where_test() {
+  let query =
+    typed_from(users())
+    |> typed_where(query.typed_eq(user_active(), True))
+    |> typed_where_raw(raw("created_at > NOW() - INTERVAL '7 days'"))
+
+  let ast_query = to_ast(query)
+  list.length(ast_query.wheres) |> should.equal(2)
+}
+
+// ============================================================================
+// TYPED_SELECT_RAW TESTS
+// ============================================================================
+
+pub fn typed_select_raw_adds_expressions_test() {
+  let query =
+    typed_from(users())
+    |> typed_select_raw([count_all()])
+
+  let ast_query = to_ast(query)
+  case ast_query.select {
+    ast.SelectExpr(exprs) -> {
+      list.length(exprs) |> should.equal(1)
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn typed_select_raw_multiple_expressions_test() {
+  let query =
+    typed_from(users())
+    |> typed_select_raw([count_all(), count_over_with_alias("total")])
+
+  let ast_query = to_ast(query)
+  case ast_query.select {
+    ast.SelectExpr(exprs) -> {
+      list.length(exprs) |> should.equal(2)
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn typed_select_raw_aliased_test() {
+  let query =
+    typed_from(users())
+    |> typed_select_raw_aliased([
+      #(count_all(), "user_count"),
+      #(now(), "query_time"),
+    ])
+
+  let ast_query = to_ast(query)
+  case ast_query.select {
+    ast.SelectExpr(exprs) -> {
+      list.length(exprs) |> should.equal(2)
+      // Check that aliases are set
+      case exprs {
+        [first, second] -> {
+          first.alias |> should.equal(Some("user_count"))
+          second.alias |> should.equal(Some("query_time"))
+        }
+        _ -> should.fail()
+      }
+    }
+    _ -> should.fail()
+  }
+}
+
+// ============================================================================
+// TYPED_ORDER_BY_RAW TESTS
+// ============================================================================
+
+pub fn typed_order_by_raw_adds_order_test() {
+  let query =
+    typed_from(users())
+    |> typed_order_by_raw(random(), ast.Asc)
+
+  let ast_query = to_ast(query)
+  list.length(ast_query.order_bys) |> should.equal(1)
+
+  case ast_query.order_bys {
+    [order] -> {
+      order.field |> should.equal("RANDOM()")
+      order.direction |> should.equal(ast.Asc)
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn typed_order_by_raw_desc_test() {
+  let query =
+    typed_from(users())
+    |> typed_order_by_raw(raw("COALESCE(updated_at, created_at)"), ast.Desc)
+
+  let ast_query = to_ast(query)
+  case ast_query.order_bys {
+    [order] -> {
+      order.field |> should.equal("COALESCE(updated_at, created_at)")
+      order.direction |> should.equal(ast.Desc)
+    }
+    _ -> should.fail()
+  }
+}
+
+// ============================================================================
+// TYPED_GROUP_BY_RAW TESTS
+// ============================================================================
+
+pub fn typed_group_by_raw_adds_group_test() {
+  let query =
+    typed_from(orders())
+    |> typed_group_by_raw(date_trunc("month", order_created_at()))
+
+  let ast_query = to_ast(query)
+  list.length(ast_query.group_bys) |> should.equal(1)
+
+  case ast_query.group_bys {
+    [group] -> {
+      group |> should.equal("DATE_TRUNC('month', created_at)")
+    }
+    _ -> should.fail()
+  }
+}
+
+// ============================================================================
+// TYPED_HAVING_RAW TESTS
+// ============================================================================
+
+pub fn typed_having_raw_adds_having_test() {
+  let query =
+    typed_from(orders())
+    |> typed_group_by_raw(raw("user_id"))
+    |> typed_having_raw(raw("COUNT(*) > 5"))
+
+  let ast_query = to_ast(query)
+  list.length(ast_query.havings) |> should.equal(1)
+
+  case ast_query.havings {
+    [ast.Where(condition)] -> {
+      case condition {
+        ast.Raw(sql, _) -> {
+          sql |> should.equal("COUNT(*) > 5")
+        }
+        _ -> should.fail()
+      }
+    }
+    _ -> should.fail()
+  }
+}
+
+// ============================================================================
+// TYPED_RAW_CONDITION TESTS
+// ============================================================================
+
+pub fn typed_raw_condition_in_where_test() {
+  let query =
+    typed_from(users())
+    |> typed_where(typed_raw_condition(raw("status IN ('active', 'pending')")))
+
+  let ast_query = to_ast(query)
+  list.length(ast_query.wheres) |> should.equal(1)
+}
+
+pub fn typed_raw_condition_with_column_raw_test() {
+  // Use column_raw_gt from the raw module
+  let query =
+    typed_from(users())
+    |> typed_where(
+      typed_raw_condition(column_raw_gt(
+        user_created_at(),
+        subtract(now(), interval(7, "days")),
+      )),
+    )
+
+  let ast_query = to_ast(query)
+  case ast_query.wheres {
+    [ast.Where(condition)] -> {
+      case condition {
+        ast.Raw(sql, _) -> {
+          sql |> should.equal("created_at > (NOW() - INTERVAL '7 days')")
+        }
+        _ -> should.fail()
+      }
+    }
+    _ -> should.fail()
+  }
+}
+
+// ============================================================================
+// COMPLEX QUERY TESTS
+// ============================================================================
+
+pub fn complete_query_with_raw_expressions_test() {
+  // Test a complete query mixing typed and raw expressions
+  let query =
+    typed_from(users())
+    |> typed_select_raw_aliased([
+      #(raw("id"), "user_id"),
+      #(raw("email"), "user_email"),
+      #(count_over_with_alias("total"), "total_count"),
+    ])
+    |> typed_where(query.typed_eq(user_active(), True))
+    |> typed_where_raw(raw("created_at > NOW() - INTERVAL '30 days'"))
+    |> typed_order_by_raw(raw("COALESCE(last_login, created_at)"), ast.Desc)
+
+  let ast_query = to_ast(query)
+
+  // Verify SELECT
+  case ast_query.select {
+    ast.SelectExpr(exprs) -> list.length(exprs) |> should.equal(3)
+    _ -> should.fail()
+  }
+
+  // Verify WHERE (2 conditions)
+  list.length(ast_query.wheres) |> should.equal(2)
+
+  // Verify ORDER BY (1 clause)
+  list.length(ast_query.order_bys) |> should.equal(1)
+}
+
+pub fn pagination_with_total_count_test() {
+  // Common pattern: Get paginated results with total count
+  let query =
+    typed_from(users())
+    |> typed_select_raw_aliased([
+      #(raw("*"), "all_columns"),
+      #(count_over_with_alias("total"), "total_count"),
+    ])
+    |> typed_where(query.typed_eq(user_active(), True))
+    |> query.typed_limit(10)
+    |> query.typed_offset(0)
+
+  let ast_query = to_ast(query)
+
+  // Verify pagination
+  ast_query.limit |> should.equal(Some(10))
+  ast_query.offset |> should.equal(Some(0))
+
+  // Verify window function in select
+  case ast_query.select {
+    ast.SelectExpr(exprs) -> list.length(exprs) |> should.equal(2)
+    _ -> should.fail()
+  }
+}
+
+pub fn aggregate_query_with_having_test() {
+  // Common pattern: Aggregate with HAVING clause
+  let query =
+    typed_from(orders())
+    |> typed_select_raw_aliased([
+      #(raw("user_id"), "user_id"),
+      #(count_all(), "order_count"),
+      #(raw("SUM(amount)"), "total"),
+    ])
+    |> typed_group_by_raw(raw("user_id"))
+    |> typed_having_raw(raw("COUNT(*) >= 3"))
+
+  let ast_query = to_ast(query)
+
+  // Verify GROUP BY
+  list.length(ast_query.group_bys) |> should.equal(1)
+
+  // Verify HAVING
+  list.length(ast_query.havings) |> should.equal(1)
+}
+
+pub fn random_order_query_test() {
+  // Get random user
+  let query =
+    typed_from(users())
+    |> typed_where(query.typed_eq(user_active(), True))
+    |> typed_order_by_raw(random(), ast.Asc)
+    |> query.typed_limit(1)
+
+  let ast_query = to_ast(query)
+
+  // Verify random ordering
+  case ast_query.order_bys {
+    [order] -> {
+      order.field |> should.equal("RANDOM()")
+    }
+    _ -> should.fail()
+  }
+
+  ast_query.limit |> should.equal(Some(1))
+}

--- a/test/cquill/typed/raw_test.gleam
+++ b/test/cquill/typed/raw_test.gleam
@@ -1,0 +1,518 @@
+// Raw SQL Escape Hatch Tests
+//
+// Tests for the raw SQL module that provides escape hatches
+// when the query builder can't express something.
+
+import cquill/query/ast
+import cquill/typed/raw.{
+  add, age_from_now, and_raw, avg, case_when, cast, cast_column, coalesce_column,
+  coalesce_int_column, coalesce_raw, column_expr, column_raw_between,
+  column_raw_eq, column_raw_gt, column_raw_gte, column_raw_lt, column_raw_lte,
+  concat, concat_columns_with_separator, count_all, count_column, count_distinct,
+  count_over, count_over_with_alias, current_date, current_time,
+  current_timestamp, date_trunc, divide, exists, extract, false_literal,
+  float_literal, in_subquery, int_literal, interval, length, lower, max, min,
+  modulo, multiply, not_exists, not_in_subquery, not_raw, now, null_literal,
+  nullif_column, or_raw, random, raw, raw_params, raw_sql, raw_to_condition,
+  raw_to_order_by, raw_with_params, row_number_over, string_literal, subtract,
+  sum, trim, true_literal, upper,
+}
+import cquill/typed/table.{type Column, column}
+import gleam/option.{type Option, None, Some}
+import gleeunit/should
+
+// ============================================================================
+// MOCK TABLE TYPES
+// ============================================================================
+
+/// Phantom type for the users table
+pub type UserTable
+
+/// Phantom type for the orders table
+pub type OrderTable
+
+// Mock column factories
+fn user_id() -> Column(UserTable, Int) {
+  column("id")
+}
+
+fn user_email() -> Column(UserTable, String) {
+  column("email")
+}
+
+fn user_name() -> Column(UserTable, String) {
+  column("name")
+}
+
+fn user_nickname() -> Column(UserTable, Option(String)) {
+  column("nickname")
+}
+
+fn user_age() -> Column(UserTable, Option(Int)) {
+  column("age")
+}
+
+fn user_status() -> Column(UserTable, String) {
+  column("status")
+}
+
+fn user_created_at() -> Column(UserTable, String) {
+  column("created_at")
+}
+
+fn order_amount() -> Column(OrderTable, Int) {
+  column("amount")
+}
+
+// ============================================================================
+// RAW EXPRESSION TESTS
+// ============================================================================
+
+pub fn raw_creates_expression_test() {
+  let expr = raw("NOW()")
+
+  raw_sql(expr)
+  |> should.equal("NOW()")
+
+  raw_params(expr)
+  |> should.equal([])
+}
+
+pub fn raw_with_params_creates_parameterized_expression_test() {
+  let expr =
+    raw_with_params("email = $1", [ast.StringValue("test@example.com")])
+
+  raw_sql(expr)
+  |> should.equal("email = $1")
+
+  raw_params(expr)
+  |> should.equal([ast.StringValue("test@example.com")])
+}
+
+pub fn raw_with_multiple_params_test() {
+  let expr =
+    raw_with_params("created_at > $1 AND status = $2", [
+      ast.StringValue("2024-01-01"),
+      ast.StringValue("active"),
+    ])
+
+  raw_sql(expr)
+  |> should.equal("created_at > $1 AND status = $2")
+
+  raw_params(expr)
+  |> should.equal([
+    ast.StringValue("2024-01-01"),
+    ast.StringValue("active"),
+  ])
+}
+
+pub fn raw_to_condition_converts_to_ast_test() {
+  let expr = raw_with_params("id = $1", [ast.IntValue(42)])
+  let condition = raw_to_condition(expr)
+
+  case condition {
+    ast.Raw(sql, params) -> {
+      sql |> should.equal("id = $1")
+      params |> should.equal([ast.IntValue(42)])
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn raw_to_order_by_creates_order_clause_test() {
+  let expr = raw("RANDOM()")
+  let order = raw_to_order_by(expr, ast.Asc)
+
+  order.field |> should.equal("RANDOM()")
+  order.direction |> should.equal(ast.Asc)
+}
+
+// ============================================================================
+// FRAGMENT HELPERS TESTS
+// ============================================================================
+
+pub fn now_creates_now_expression_test() {
+  let expr = now()
+  raw_sql(expr) |> should.equal("NOW()")
+}
+
+pub fn current_timestamp_test() {
+  let expr = current_timestamp()
+  raw_sql(expr) |> should.equal("CURRENT_TIMESTAMP")
+}
+
+pub fn current_date_test() {
+  let expr = current_date()
+  raw_sql(expr) |> should.equal("CURRENT_DATE")
+}
+
+pub fn current_time_test() {
+  let expr = current_time()
+  raw_sql(expr) |> should.equal("CURRENT_TIME")
+}
+
+pub fn interval_creates_interval_expression_test() {
+  let expr = interval(7, "days")
+  raw_sql(expr) |> should.equal("INTERVAL '7 days'")
+}
+
+pub fn interval_with_hour_test() {
+  let expr = interval(1, "hour")
+  raw_sql(expr) |> should.equal("INTERVAL '1 hour'")
+}
+
+pub fn interval_with_minutes_test() {
+  let expr = interval(30, "minutes")
+  raw_sql(expr) |> should.equal("INTERVAL '30 minutes'")
+}
+
+pub fn coalesce_column_creates_coalesce_test() {
+  let expr = coalesce_column(user_nickname(), "Anonymous")
+  raw_sql(expr) |> should.equal("COALESCE(nickname, 'Anonymous')")
+}
+
+pub fn coalesce_int_column_test() {
+  let expr = coalesce_int_column(user_age(), 0)
+  raw_sql(expr) |> should.equal("COALESCE(age, 0)")
+}
+
+pub fn coalesce_raw_test() {
+  let expr = coalesce_raw([raw("nickname"), raw("'Guest'")])
+  raw_sql(expr) |> should.equal("COALESCE(nickname, 'Guest')")
+}
+
+pub fn nullif_column_test() {
+  let expr = nullif_column(user_status(), "deleted")
+  raw_sql(expr) |> should.equal("NULLIF(status, 'deleted')")
+}
+
+pub fn cast_expression_test() {
+  let expr = cast(raw("'123'"), "INTEGER")
+  raw_sql(expr) |> should.equal("CAST('123' AS INTEGER)")
+}
+
+pub fn cast_column_test() {
+  let expr = cast_column(user_created_at(), "DATE")
+  raw_sql(expr) |> should.equal("CAST(created_at AS DATE)")
+}
+
+pub fn random_test() {
+  let expr = random()
+  raw_sql(expr) |> should.equal("RANDOM()")
+}
+
+// ============================================================================
+// AGGREGATE FUNCTION TESTS
+// ============================================================================
+
+pub fn count_all_test() {
+  let expr = count_all()
+  raw_sql(expr) |> should.equal("COUNT(*)")
+}
+
+pub fn count_column_test() {
+  let expr = count_column(user_id())
+  raw_sql(expr) |> should.equal("COUNT(id)")
+}
+
+pub fn count_distinct_test() {
+  let expr = count_distinct(user_email())
+  raw_sql(expr) |> should.equal("COUNT(DISTINCT email)")
+}
+
+pub fn sum_test() {
+  let expr = sum(order_amount())
+  raw_sql(expr) |> should.equal("SUM(amount)")
+}
+
+pub fn avg_test() {
+  let expr = avg(order_amount())
+  raw_sql(expr) |> should.equal("AVG(amount)")
+}
+
+pub fn min_test() {
+  let expr = min(order_amount())
+  raw_sql(expr) |> should.equal("MIN(amount)")
+}
+
+pub fn max_test() {
+  let expr = max(order_amount())
+  raw_sql(expr) |> should.equal("MAX(amount)")
+}
+
+pub fn count_over_test() {
+  let expr = count_over()
+  raw_sql(expr) |> should.equal("COUNT(*) OVER ()")
+}
+
+pub fn count_over_with_alias_test() {
+  let expr = count_over_with_alias("total_count")
+  raw_sql(expr) |> should.equal("COUNT(*) OVER () AS total_count")
+}
+
+pub fn row_number_over_test() {
+  let expr = row_number_over(user_id(), ast.Desc)
+  raw_sql(expr) |> should.equal("ROW_NUMBER() OVER (ORDER BY id DESC)")
+}
+
+// ============================================================================
+// STRING FUNCTION TESTS
+// ============================================================================
+
+pub fn lower_test() {
+  let expr = lower(user_email())
+  raw_sql(expr) |> should.equal("LOWER(email)")
+}
+
+pub fn upper_test() {
+  let expr = upper(user_name())
+  raw_sql(expr) |> should.equal("UPPER(name)")
+}
+
+pub fn trim_test() {
+  let expr = trim(user_name())
+  raw_sql(expr) |> should.equal("TRIM(name)")
+}
+
+pub fn length_test() {
+  let expr = length(user_name())
+  raw_sql(expr) |> should.equal("LENGTH(name)")
+}
+
+pub fn concat_test() {
+  let expr = concat([raw("first_name"), raw("' '"), raw("last_name")])
+  raw_sql(expr) |> should.equal("CONCAT(first_name, ' ', last_name)")
+}
+
+pub fn concat_columns_with_separator_test() {
+  let expr = concat_columns_with_separator([user_name(), user_email()], " - ")
+  raw_sql(expr) |> should.equal("name || ' - ' || email")
+}
+
+// ============================================================================
+// DATE/TIME FUNCTION TESTS
+// ============================================================================
+
+pub fn extract_test() {
+  let expr = extract("year", user_created_at())
+  raw_sql(expr) |> should.equal("EXTRACT(year FROM created_at)")
+}
+
+pub fn extract_month_test() {
+  let expr = extract("month", user_created_at())
+  raw_sql(expr) |> should.equal("EXTRACT(month FROM created_at)")
+}
+
+pub fn date_trunc_test() {
+  let expr = date_trunc("month", user_created_at())
+  raw_sql(expr) |> should.equal("DATE_TRUNC('month', created_at)")
+}
+
+pub fn age_from_now_test() {
+  let expr = age_from_now(user_created_at())
+  raw_sql(expr) |> should.equal("AGE(created_at)")
+}
+
+// ============================================================================
+// CASE EXPRESSION TESTS
+// ============================================================================
+
+pub fn case_when_test() {
+  let expr =
+    case_when(
+      [
+        #(raw("status = 'active'"), raw("'Active'")),
+        #(raw("status = 'pending'"), raw("'Pending'")),
+      ],
+      raw("'Unknown'"),
+    )
+  raw_sql(expr)
+  |> should.equal(
+    "CASE WHEN status = 'active' THEN 'Active' WHEN status = 'pending' THEN 'Pending' ELSE 'Unknown' END",
+  )
+}
+
+// ============================================================================
+// SUBQUERY TESTS
+// ============================================================================
+
+pub fn exists_test() {
+  let expr = exists(raw("SELECT 1 FROM orders WHERE orders.user_id = users.id"))
+  raw_sql(expr)
+  |> should.equal(
+    "EXISTS (SELECT 1 FROM orders WHERE orders.user_id = users.id)",
+  )
+}
+
+pub fn not_exists_test() {
+  let expr = not_exists(raw("SELECT 1 FROM bans WHERE bans.user_id = users.id"))
+  raw_sql(expr)
+  |> should.equal(
+    "NOT EXISTS (SELECT 1 FROM bans WHERE bans.user_id = users.id)",
+  )
+}
+
+pub fn in_subquery_test() {
+  let expr = in_subquery(user_id(), raw("SELECT id FROM active_users"))
+  raw_sql(expr) |> should.equal("id IN (SELECT id FROM active_users)")
+}
+
+pub fn not_in_subquery_test() {
+  let expr = not_in_subquery(user_id(), raw("SELECT id FROM banned_users"))
+  raw_sql(expr) |> should.equal("id NOT IN (SELECT id FROM banned_users)")
+}
+
+// ============================================================================
+// COMPARISON HELPER TESTS
+// ============================================================================
+
+pub fn column_raw_eq_test() {
+  let expr = column_raw_eq(user_created_at(), now())
+  raw_sql(expr) |> should.equal("created_at = NOW()")
+}
+
+pub fn column_raw_gt_test() {
+  let expr = column_raw_gt(user_created_at(), raw("NOW() - INTERVAL '7 days'"))
+  raw_sql(expr) |> should.equal("created_at > NOW() - INTERVAL '7 days'")
+}
+
+pub fn column_raw_gte_test() {
+  let expr = column_raw_gte(user_created_at(), raw("'2024-01-01'"))
+  raw_sql(expr) |> should.equal("created_at >= '2024-01-01'")
+}
+
+pub fn column_raw_lt_test() {
+  let expr = column_raw_lt(user_created_at(), now())
+  raw_sql(expr) |> should.equal("created_at < NOW()")
+}
+
+pub fn column_raw_lte_test() {
+  let expr = column_raw_lte(user_created_at(), now())
+  raw_sql(expr) |> should.equal("created_at <= NOW()")
+}
+
+pub fn column_raw_between_test() {
+  let expr =
+    column_raw_between(
+      user_created_at(),
+      raw("'2024-01-01'"),
+      raw("'2024-12-31'"),
+    )
+  raw_sql(expr)
+  |> should.equal("created_at BETWEEN '2024-01-01' AND '2024-12-31'")
+}
+
+// ============================================================================
+// ARITHMETIC HELPER TESTS
+// ============================================================================
+
+pub fn add_test() {
+  let expr = add(column_expr(order_amount()), int_literal(100))
+  raw_sql(expr) |> should.equal("(amount + 100)")
+}
+
+pub fn subtract_test() {
+  let expr = subtract(column_expr(order_amount()), int_literal(10))
+  raw_sql(expr) |> should.equal("(amount - 10)")
+}
+
+pub fn multiply_test() {
+  let expr = multiply(column_expr(order_amount()), int_literal(2))
+  raw_sql(expr) |> should.equal("(amount * 2)")
+}
+
+pub fn divide_test() {
+  let expr = divide(column_expr(order_amount()), int_literal(2))
+  raw_sql(expr) |> should.equal("(amount / 2)")
+}
+
+pub fn modulo_test() {
+  let expr = modulo(column_expr(order_amount()), int_literal(10))
+  raw_sql(expr) |> should.equal("(amount % 10)")
+}
+
+// ============================================================================
+// LITERAL TESTS
+// ============================================================================
+
+pub fn int_literal_test() {
+  let expr = int_literal(42)
+  raw_sql(expr) |> should.equal("42")
+}
+
+pub fn int_literal_negative_test() {
+  let expr = int_literal(-5)
+  raw_sql(expr) |> should.equal("-5")
+}
+
+pub fn string_literal_test() {
+  let expr = string_literal("hello")
+  raw_sql(expr) |> should.equal("'hello'")
+}
+
+pub fn string_literal_with_quote_test() {
+  let expr = string_literal("it's")
+  raw_sql(expr) |> should.equal("'it''s'")
+}
+
+pub fn true_literal_test() {
+  let expr = true_literal()
+  raw_sql(expr) |> should.equal("TRUE")
+}
+
+pub fn false_literal_test() {
+  let expr = false_literal()
+  raw_sql(expr) |> should.equal("FALSE")
+}
+
+pub fn null_literal_test() {
+  let expr = null_literal()
+  raw_sql(expr) |> should.equal("NULL")
+}
+
+// ============================================================================
+// LOGICAL OPERATOR TESTS
+// ============================================================================
+
+pub fn and_raw_test() {
+  let expr = and_raw([raw("status = 'active'"), raw("age > 18")])
+  raw_sql(expr) |> should.equal("(status = 'active' AND age > 18)")
+}
+
+pub fn or_raw_test() {
+  let expr = or_raw([raw("status = 'active'"), raw("status = 'pending'")])
+  raw_sql(expr) |> should.equal("(status = 'active' OR status = 'pending')")
+}
+
+pub fn not_raw_test() {
+  let expr = not_raw(raw("deleted"))
+  raw_sql(expr) |> should.equal("NOT (deleted)")
+}
+
+// ============================================================================
+// COMPLEX EXPRESSION TESTS
+// ============================================================================
+
+pub fn complex_date_calculation_test() {
+  // Example: created_at > NOW() - INTERVAL '7 days'
+  let expr =
+    column_raw_gt(user_created_at(), subtract(now(), interval(7, "days")))
+  raw_sql(expr)
+  |> should.equal("created_at > (NOW() - INTERVAL '7 days')")
+}
+
+pub fn nested_coalesce_test() {
+  // COALESCE(nickname, name, 'Anonymous')
+  let expr =
+    coalesce_raw([raw("nickname"), raw("name"), string_literal("Anonymous")])
+  raw_sql(expr) |> should.equal("COALESCE(nickname, name, 'Anonymous')")
+}
+
+pub fn combined_aggregate_test() {
+  // Test combining multiple aggregates
+  let count_expr = count_all()
+  let sum_expr = sum(order_amount())
+
+  raw_sql(count_expr) |> should.equal("COUNT(*)")
+  raw_sql(sum_expr) |> should.equal("SUM(amount)")
+}


### PR DESCRIPTION
## Summary

- Add `RawExpr` opaque type for raw SQL expressions with optional parameters
- Implement 60+ fragment helpers for common SQL patterns (date/time, aggregates, strings, conditionals)
- Add query integration functions to mix raw SQL with typed queries
- Comprehensive test suite with 84 new tests

Closes #28

## Implementation Details

### RawExpr Type
- Opaque type containing SQL string and parameter list
- `raw(sql)` - Create raw expression without parameters
- `raw_with_params(sql, params)` - Create parameterized expression (prevents SQL injection)

### Fragment Helpers
**Date/Time:**
- `now()`, `current_timestamp()`, `current_date()`, `current_time()`
- `interval(amount, unit)` - Generate INTERVAL expressions
- `extract(field, column)`, `date_trunc(precision, column)`

**Aggregates:**
- `count_all()`, `count_column(col)`, `count_distinct(col)`
- `sum(col)`, `avg(col)`, `min(col)`, `max(col)`
- `count_over()`, `count_over_with_alias(alias)` - Window functions
- `row_number_over(col, direction)`

**String Functions:**
- `lower(col)`, `upper(col)`, `trim(col)`, `length(col)`
- `concat(exprs)`, `concat_columns_with_separator(cols, sep)`

**Conditionals:**
- `coalesce_column(col, default)`, `coalesce_raw(exprs)`
- `nullif_column(col, value)`
- `case_when(conditions, else_expr)`

**Subqueries:**
- `exists(subquery)`, `not_exists(subquery)`
- `in_subquery(col, subquery)`, `not_in_subquery(col, subquery)`

**Comparisons:**
- `column_raw_eq(col, expr)`, `column_raw_gt(col, expr)`, etc.
- `column_raw_between(col, low, high)`

**Arithmetic:**
- `add(a, b)`, `subtract(a, b)`, `multiply(a, b)`, `divide(a, b)`, `modulo(a, b)`

**Literals:**
- `int_literal(n)`, `string_literal(s)`, `float_literal(f)`
- `true_literal()`, `false_literal()`, `null_literal()`

### Query Integration
```gleam
// Mix typed and raw in queries
typed_from(users)
|> typed_select_raw_aliased([
    #(raw("*"), "all_columns"),
    #(count_over_with_alias("total"), "total_count"),
  ])
|> typed_where(typed_eq(active, True))
|> typed_where_raw(raw("created_at > NOW() - INTERVAL '7 days'"))
|> typed_order_by_raw(random(), Asc)
```

## Test plan

- [x] Run `gleam test` - all 836 tests pass (84 new tests)
- [x] Run `gleam format --check` - formatting verified

## Example Usage

```gleam
import cquill/typed/raw.{
  raw, raw_with_params, now, interval, count_over_with_alias, random
}
import cquill/typed/query.{
  typed_from, typed_where_raw, typed_select_raw_aliased, typed_order_by_raw
}

// Parameterized raw SQL (safe from SQL injection)
typed_from(users)
|> typed_where_raw(raw_with_params("email = $1", [StringValue(user_input)]))

// Window functions for pagination with total count
typed_from(users)
|> typed_select_raw_aliased([
    #(raw("*"), "data"),
    #(count_over_with_alias("total"), "total"),
  ])
|> typed_limit(10)

// Random ordering
typed_from(users)
|> typed_order_by_raw(random(), Asc)
|> typed_limit(1)

// Date comparisons using fragments
typed_from(users)
|> typed_where_raw(
    column_raw_gt(created_at, subtract(now(), interval(7, "days")))
  )
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)