### PR TITLE
docs: add comprehensive documentation for cquill

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,83 @@
+# cquill Documentation
+
+Welcome to the cquill documentation. cquill is a compile-time safe data access library for Gleam, inspired by Ecto but designed specifically for Gleam's type system and idioms.
+
+## Quick Links
+
+- [Getting Started](./getting-started.md) - Installation and first query
+- [API Reference](./reference/api.md) - Complete API documentation
+- [Examples](./examples/) - Working code examples
+
+## Documentation Structure
+
+### Concepts
+
+Understand the core ideas behind cquill:
+
+- [Schemas](./concepts/schemas.md) - How schemas describe your data
+- [Queries](./concepts/queries.md) - Building type-safe queries
+- [Repo](./concepts/repo.md) - The repository pattern for data access
+- [Adapters](./concepts/adapters.md) - Abstraction over different backends
+
+### Guides
+
+Step-by-step tutorials for common tasks:
+
+- [CRUD Operations](./guides/crud.md) - Create, read, update, delete
+- [Advanced Queries](./guides/queries.md) - Joins, aggregations, subqueries
+- [Transactions](./guides/transactions.md) - Transaction patterns and savepoints
+- [Testing](./guides/testing.md) - Test strategies with cquill
+- [Migrations](./MIGRATIONS.md) - Database migration integration
+
+### Reference
+
+Detailed technical reference:
+
+- [API Reference](./reference/api.md) - All public functions
+- [Types Reference](./reference/types.md) - All public types
+- [Errors Reference](./reference/errors.md) - Error types and handling
+- [Configuration](./reference/config.md) - Configuration options
+
+### Recipes
+
+Real-world patterns and solutions:
+
+- [Pagination](./recipes/pagination.md) - Offset and cursor pagination
+- [Soft Delete](./recipes/soft-delete.md) - Soft delete pattern
+- [Audit Logging](./recipes/audit-log.md) - Track changes
+- [Multi-tenancy](./recipes/multi-tenant.md) - Multi-tenant queries
+
+## Design Philosophy
+
+cquill is built on these principles:
+
+1. **Compile-time safety over runtime convenience** - Invalid queries fail at compile time
+2. **Explicit over implicit** - No magic; transformations are visible
+3. **Gleam-idiomatic** - Leverage Result types, pipelines, and the module system
+4. **Adapter-first** - Same API works with any backend
+5. **Small, composable modules** - Each module has one responsibility
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────┐
+│           Your Application              │
+├─────────────────────────────────────────┤
+│  Schema    │  Changeset  │    Query     │  ← Pure, no I/O
+│  (types)   │ (validation)│   (builder)  │
+├─────────────────────────────────────────┤
+│                  Repo                   │  ← Public API
+├─────────────────────────────────────────┤
+│  Memory    │  Postgres   │   (Future)   │  ← Adapters
+│  Adapter   │  Adapter    │   Adapters   │
+└─────────────────────────────────────────┘
+```
+
+## Getting Help
+
+- [GitHub Issues](https://github.com/justin4957/cquill/issues) - Report bugs or request features
+- [GitHub Discussions](https://github.com/justin4957/cquill/discussions) - Ask questions
+
+## Contributing
+
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for guidelines on contributing to cquill.

--- a/docs/concepts/adapters.md
+++ b/docs/concepts/adapters.md
@@ -1,0 +1,350 @@
+# Adapters
+
+Adapters in cquill provide the abstraction layer between your queries and the underlying database. This separation enables testing with in-memory stores and deploying with real databases using identical application code.
+
+## What is an Adapter?
+
+An adapter translates cquill queries into backend-specific operations:
+
+```
+┌─────────────────────┐
+│   cquill Query      │  query.from("users") |> query.where(...)
+└─────────────────────┘
+          │
+          ▼
+┌─────────────────────┐
+│      Adapter        │  Translates to backend-specific format
+└─────────────────────┘
+          │
+          ▼
+┌─────────────────────┐
+│     Backend         │  Memory / PostgreSQL / SQLite / etc.
+└─────────────────────┘
+```
+
+## Available Adapters
+
+### Memory Adapter
+
+The in-memory adapter stores data in Gleam data structures. Perfect for:
+
+- Unit testing
+- Development without a database
+- Prototyping
+
+```gleam
+import cquill/adapter/memory
+
+// Create a new store
+let store = memory.new_store()
+
+// Create tables
+let store = memory.create_table(store, "users", ["id", "email", "name"])
+
+// Insert data
+let store = memory.insert_row(store, "users", dict.from_list([
+  #("id", ast.IntValue(1)),
+  #("email", ast.StringValue("alice@example.com")),
+  #("name", ast.StringValue("Alice")),
+]))
+
+// Execute queries
+let result = memory.execute_select(store, query)
+```
+
+#### Memory Adapter Features
+
+| Feature | Supported |
+|---------|-----------|
+| SELECT queries | Yes |
+| INSERT | Yes |
+| UPDATE | Yes |
+| DELETE | Yes |
+| Transactions | Yes |
+| Savepoints | Yes |
+| Batch operations | Yes |
+| JOINs | Yes |
+| ORDER BY | Yes |
+| LIMIT/OFFSET | Yes |
+| Aggregations | Partial |
+
+### PostgreSQL Adapter
+
+The PostgreSQL adapter connects to real PostgreSQL databases:
+
+```gleam
+import cquill/adapter/postgres
+
+// Configuration
+let config = postgres.Config(
+  host: "localhost",
+  port: 5432,
+  database: "myapp_dev",
+  user: "postgres",
+  password: "password",
+  pool_size: 10,
+)
+
+// Connect
+use pool <- result.try(postgres.connect(config))
+
+// Execute queries
+let result = postgres.execute_select(pool, query)
+```
+
+## Adapter Protocol
+
+All adapters implement the same interface, defined by the adapter behavior:
+
+```gleam
+// Core operations every adapter must implement
+pub type AdapterBehaviour {
+  // Query execution
+  execute_select: fn(Adapter, Query) -> Result(List(Row), AdapterError)
+  execute_insert: fn(Adapter, InsertQuery) -> Result(List(Row), AdapterError)
+  execute_update: fn(Adapter, UpdateQuery) -> Result(List(Row), AdapterError)
+  execute_delete: fn(Adapter, DeleteQuery) -> Result(Int, AdapterError)
+
+  // Transaction support
+  begin_transaction: fn(Adapter) -> Result(Transaction, AdapterError)
+  commit_transaction: fn(Transaction) -> Result(Nil, AdapterError)
+  rollback_transaction: fn(Transaction) -> Result(Nil, AdapterError)
+
+  // Savepoint support
+  create_savepoint: fn(Transaction, String) -> Result(Savepoint, AdapterError)
+  release_savepoint: fn(Savepoint) -> Result(Nil, AdapterError)
+  rollback_to_savepoint: fn(Savepoint) -> Result(Nil, AdapterError)
+}
+```
+
+## Using Adapters
+
+### Consistent API
+
+The same code works with any adapter:
+
+```gleam
+import cquill/repo
+
+// Function works with any adapter
+pub fn get_active_users(adapter) {
+  let query =
+    query.from("users")
+    |> query.where(query.eq("active", ast.BoolValue(True)))
+
+  repo.all(adapter, query)
+}
+
+// In tests - use memory adapter
+let store = memory.new_store() |> setup_test_data()
+get_active_users(store)
+
+// In production - use PostgreSQL
+use pool <- result.try(postgres.connect(config))
+get_active_users(pool)
+```
+
+### Adapter-Specific Configuration
+
+Each adapter has its own configuration:
+
+```gleam
+// Memory adapter - no configuration needed
+let memory_adapter = memory.new_store()
+
+// PostgreSQL - connection configuration
+let pg_config = postgres.Config(
+  host: env.get("DB_HOST"),
+  port: env.get_int("DB_PORT"),
+  database: env.get("DB_NAME"),
+  user: env.get("DB_USER"),
+  password: env.get("DB_PASSWORD"),
+  pool_size: env.get_int("DB_POOL_SIZE"),
+  ssl: env.get_bool("DB_SSL"),
+  timeout: env.get_int("DB_TIMEOUT"),
+)
+```
+
+## Writing Custom Adapters
+
+You can create adapters for other databases by implementing the adapter protocol.
+
+### Basic Structure
+
+```gleam
+// my_adapter.gleam
+import cquill/error.{type AdapterError}
+import cquill/query/ast.{type Query, type InsertQuery, type UpdateQuery, type DeleteQuery}
+
+pub opaque type MyAdapter {
+  MyAdapter(connection: SomeConnection)
+}
+
+pub fn connect(config: MyConfig) -> Result(MyAdapter, AdapterError) {
+  // Initialize connection
+}
+
+pub fn execute_select(
+  adapter: MyAdapter,
+  query: Query(a),
+) -> Result(List(Row), AdapterError) {
+  // Compile query to backend format
+  let sql = compile_select(query)
+
+  // Execute and convert results
+  case execute(adapter.connection, sql) {
+    Ok(rows) -> Ok(convert_rows(rows))
+    Error(e) -> Error(convert_error(e))
+  }
+}
+
+// Implement other operations...
+```
+
+### Query Compilation
+
+Convert cquill AST to your backend's format:
+
+```gleam
+fn compile_select(query: Query(a)) -> String {
+  let table = case query.source {
+    ast.TableSource(table, None) -> table
+    ast.TableSource(table, Some(schema)) -> schema <> "." <> table
+  }
+
+  let select = case query.select {
+    ast.SelectAll -> "*"
+    ast.SelectFields(fields) -> string.join(fields, ", ")
+  }
+
+  let where_clause = compile_wheres(query.wheres)
+  let order_clause = compile_order_by(query.order_bys)
+  let limit_clause = compile_limit(query.limit, query.offset)
+
+  "SELECT " <> select <> " FROM " <> table
+    <> where_clause <> order_clause <> limit_clause
+}
+```
+
+### Error Conversion
+
+Map backend errors to cquill errors:
+
+```gleam
+fn convert_error(backend_error: BackendError) -> AdapterError {
+  case backend_error {
+    BackendNotFound -> error.NotFound
+    BackendTimeout -> error.Timeout
+    BackendDuplicate(key) -> error.UniqueViolation(key, "")
+    BackendForeignKey(key) -> error.ForeignKeyViolation(key, "")
+    BackendQuery(msg, code) -> error.QueryFailed(msg, Some(code))
+    _ -> error.AdapterSpecific("unknown", backend_error.message)
+  }
+}
+```
+
+## Testing with Adapters
+
+### Unit Tests with Memory Adapter
+
+```gleam
+import gleeunit/should
+import cquill/adapter/memory
+
+pub fn test_user_creation() {
+  // Setup
+  let store = memory.new_store()
+    |> memory.create_table("users", ["id", "email", "name"])
+
+  // Test
+  let store = memory.insert_row(store, "users", dict.from_list([
+    #("id", ast.IntValue(1)),
+    #("email", ast.StringValue("test@example.com")),
+    #("name", ast.StringValue("Test")),
+  ]))
+
+  // Assert
+  let query = query.from("users")
+    |> query.where(query.eq("id", ast.IntValue(1)))
+
+  memory.execute_select(store, query)
+  |> should.be_ok()
+  |> list.length()
+  |> should.equal(1)
+}
+```
+
+### Integration Tests with Real Database
+
+```gleam
+pub fn test_user_creation_postgres() {
+  use pool <- setup_test_database()
+
+  // Test runs against real PostgreSQL
+  let result = repo.insert(pool, create_user_query())
+
+  result
+  |> should.be_ok()
+}
+
+fn setup_test_database() -> fn(fn(Pool) -> a) -> a {
+  fn(test_fn) {
+    let pool = postgres.connect(test_config())
+    postgres.begin_transaction(pool)
+
+    let result = test_fn(pool)
+
+    // Rollback to keep test database clean
+    postgres.rollback_transaction(pool)
+    result
+  }
+}
+```
+
+## Best Practices
+
+### 1. Abstract Adapter Access
+
+```gleam
+// Good: Pass adapter as parameter
+pub fn get_user(adapter, id: Int) {
+  repo.one(adapter, user_by_id_query(id))
+}
+
+// Avoid: Hardcode adapter choice
+pub fn get_user_bad(id: Int) {
+  repo.one(postgres.global_pool(), user_by_id_query(id))
+}
+```
+
+### 2. Use Memory Adapter for Unit Tests
+
+```gleam
+// Unit tests should be fast and isolated
+pub fn test_business_logic() {
+  let adapter = memory.new_store() |> setup_fixtures()
+
+  // Test your logic without database I/O
+  my_business_function(adapter)
+  |> should.be_ok()
+}
+```
+
+### 3. Integration Tests for Adapter-Specific Behavior
+
+```gleam
+// Test real database behavior separately
+pub fn test_postgres_specific() {
+  use pool <- setup_postgres()
+
+  // Test things like constraints, indexes, etc.
+  repo.insert(pool, duplicate_key_insert())
+  |> should.equal(Error(error.UniqueViolation(_, _)))
+}
+```
+
+## Next Steps
+
+- See the [Adapter Contract](../ADAPTER_CONTRACT.md) for detailed specifications
+- Learn about [Testing](../guides/testing.md) strategies
+- Read the [Memory Adapter API](../reference/api.md#memory-adapter)

--- a/docs/concepts/queries.md
+++ b/docs/concepts/queries.md
@@ -1,0 +1,356 @@
+# Queries
+
+Queries in cquill are data structures, not strings. This fundamental design choice enables type safety, composition, and inspection that string-based queries cannot provide.
+
+## Queries as Data
+
+Every query in cquill is represented as an Abstract Syntax Tree (AST):
+
+```gleam
+import cquill/query
+import cquill/query/ast
+
+// This creates a Query data structure, not a SQL string
+let my_query =
+  query.from("users")
+  |> query.where(query.eq("active", ast.BoolValue(True)))
+  |> query.order_by_asc("created_at")
+  |> query.limit(10)
+```
+
+The query above produces a data structure like:
+
+```gleam
+Query(
+  source: TableSource(table: "users", schema_name: None),
+  select: SelectAll,
+  wheres: [Where(Eq("active", BoolValue(True)))],
+  order_bys: [OrderBy("created_at", Asc, NullsDefault)],
+  limit: Some(10),
+  offset: None,
+  joins: [],
+  distinct: False,
+  group_bys: [],
+  havings: [],
+)
+```
+
+## Building Queries
+
+### FROM Clause
+
+Start every query by specifying the source table:
+
+```gleam
+// Simple table reference
+query.from("users")
+
+// With schema qualification
+query.from_qualified("public", "users")
+```
+
+### SELECT Clause
+
+Specify which columns to retrieve:
+
+```gleam
+// Select all columns (default)
+query.from("users")
+|> query.select_all()
+
+// Select specific columns
+query.from("users")
+|> query.select(["id", "email", "name"])
+
+// Select with expressions
+query.from("users")
+|> query.select_expr([
+  ast.ColumnExpr("id"),
+  ast.AggregateExpr(ast.Count, "id"),
+])
+```
+
+### WHERE Clause
+
+Filter results with conditions:
+
+```gleam
+import cquill/query/ast
+
+// Single condition
+query.from("users")
+|> query.where(query.eq("active", ast.BoolValue(True)))
+
+// Multiple conditions (AND)
+query.from("users")
+|> query.where(query.eq("active", ast.BoolValue(True)))
+|> query.where(query.gt("age", ast.IntValue(18)))
+
+// OR conditions
+query.from("users")
+|> query.where(query.or_where([
+  query.eq("role", ast.StringValue("admin")),
+  query.eq("role", ast.StringValue("moderator")),
+]))
+
+// Complex conditions
+query.from("users")
+|> query.where(query.and_where([
+  query.eq("active", ast.BoolValue(True)),
+  query.or_where([
+    query.gt("age", ast.IntValue(21)),
+    query.eq("verified", ast.BoolValue(True)),
+  ]),
+]))
+```
+
+### Condition Types
+
+```gleam
+// Equality
+query.eq("field", value)
+query.not_eq("field", value)
+
+// Comparison
+query.gt("field", value)   // Greater than
+query.gte("field", value)  // Greater than or equal
+query.lt("field", value)   // Less than
+query.lte("field", value)  // Less than or equal
+
+// Pattern matching
+query.like("name", "%smith%")
+query.not_like("name", "%test%")
+query.ilike("name", "%SMITH%")  // Case insensitive
+
+// NULL checks
+query.is_null("deleted_at")
+query.is_not_null("email")
+
+// IN clause
+query.in_list("status", [
+  ast.StringValue("pending"),
+  ast.StringValue("active"),
+])
+query.not_in_list("status", [ast.StringValue("deleted")])
+
+// BETWEEN
+query.between("age", ast.IntValue(18), ast.IntValue(65))
+
+// Negation
+query.not_where(query.eq("role", ast.StringValue("guest")))
+```
+
+### ORDER BY Clause
+
+Sort results:
+
+```gleam
+// Ascending order
+query.from("users")
+|> query.order_by_asc("created_at")
+
+// Descending order
+query.from("users")
+|> query.order_by_desc("score")
+
+// Multiple sort columns
+query.from("users")
+|> query.order_by_desc("score")
+|> query.order_by_asc("name")
+
+// With NULL handling
+query.from("users")
+|> query.order_by("score", ast.Desc, ast.NullsLast)
+```
+
+### LIMIT and OFFSET
+
+Paginate results:
+
+```gleam
+// Limit results
+query.from("users")
+|> query.limit(10)
+
+// With offset (for pagination)
+query.from("users")
+|> query.limit(10)
+|> query.offset(20)  // Skip first 20 rows
+```
+
+### DISTINCT
+
+Remove duplicate rows:
+
+```gleam
+query.from("users")
+|> query.select(["country"])
+|> query.distinct()
+```
+
+### GROUP BY and HAVING
+
+Aggregate data:
+
+```gleam
+query.from("orders")
+|> query.select_expr([
+  ast.ColumnExpr("customer_id"),
+  ast.AggregateExpr(ast.Sum, "total"),
+])
+|> query.group_by(["customer_id"])
+|> query.having(query.gt("sum_total", ast.IntValue(1000)))
+```
+
+### JOIN Clause
+
+Join multiple tables:
+
+```gleam
+query.from("orders")
+|> query.inner_join("customers", query.eq("orders.customer_id", "customers.id"))
+|> query.left_join("products", query.eq("orders.product_id", "products.id"))
+|> query.select(["orders.id", "customers.name", "products.title"])
+```
+
+Join types:
+- `query.inner_join()` - Only matching rows
+- `query.left_join()` - All left rows, matching right rows
+- `query.right_join()` - All right rows, matching left rows
+- `query.full_join()` - All rows from both tables
+
+## Query Composition
+
+Queries are immutable and composable:
+
+```gleam
+// Base query
+let users = query.from("users")
+
+// Add conditions to create new queries
+let active_users = users
+  |> query.where(query.eq("active", ast.BoolValue(True)))
+
+let admin_users = users
+  |> query.where(query.eq("role", ast.StringValue("admin")))
+
+// Combine for reusable query parts
+fn paginated(q, page, per_page) {
+  q
+  |> query.limit(per_page)
+  |> query.offset((page - 1) * per_page)
+}
+
+let page_1 = active_users |> paginated(1, 20)
+let page_2 = active_users |> paginated(2, 20)
+```
+
+### Query Functions
+
+Create reusable query builders:
+
+```gleam
+// Filter by date range
+fn created_between(q, start_date, end_date) {
+  q
+  |> query.where(query.gte("created_at", ast.StringValue(start_date)))
+  |> query.where(query.lt("created_at", ast.StringValue(end_date)))
+}
+
+// Filter by search term
+fn search_name(q, term) {
+  q
+  |> query.where(query.ilike("name", "%" <> term <> "%"))
+}
+
+// Combine multiple filters
+let results =
+  query.from("users")
+  |> created_between("2024-01-01", "2024-12-31")
+  |> search_name("john")
+  |> query.order_by_asc("name")
+```
+
+## INSERT, UPDATE, DELETE Queries
+
+### INSERT
+
+```gleam
+import cquill/query/ast
+
+// Single row insert
+let insert_query =
+  ast.new_insert("users")
+  |> ast.insert_columns(["email", "name"])
+  |> ast.insert_values([[
+    ast.StringValue("alice@example.com"),
+    ast.StringValue("Alice"),
+  ]])
+  |> ast.returning(["id"])
+
+// Multiple row insert
+let bulk_insert =
+  ast.new_insert("users")
+  |> ast.insert_columns(["email", "name"])
+  |> ast.insert_values([
+    [ast.StringValue("alice@example.com"), ast.StringValue("Alice")],
+    [ast.StringValue("bob@example.com"), ast.StringValue("Bob")],
+  ])
+```
+
+### UPDATE
+
+```gleam
+let update_query =
+  ast.new_update("users")
+  |> ast.set("name", ast.StringValue("Alice Smith"))
+  |> ast.set("updated_at", ast.StringValue("2024-01-15T10:00:00Z"))
+  |> ast.update_where(query.eq("id", ast.IntValue(1)))
+  |> ast.returning(["id", "name"])
+```
+
+### DELETE
+
+```gleam
+let delete_query =
+  ast.new_delete("users")
+  |> ast.delete_where(query.eq("id", ast.IntValue(1)))
+  |> ast.returning(["id"])
+```
+
+## Raw SQL
+
+For complex queries that can't be expressed with the builder:
+
+```gleam
+// Raw condition
+query.from("users")
+|> query.where(query.raw("age > ? AND verified = ?", [
+  ast.IntValue(18),
+  ast.BoolValue(True),
+]))
+```
+
+## Query Inspection
+
+Since queries are data, you can inspect them:
+
+```gleam
+// Get the table name
+let table = case my_query.source {
+  ast.TableSource(table, _) -> table
+  _ -> "unknown"
+}
+
+// Count WHERE conditions
+let condition_count = list.length(my_query.wheres)
+
+// Check if query has pagination
+let is_paginated = option.is_some(my_query.limit)
+```
+
+## Next Steps
+
+- Learn about the [Repo](./repo.md) for executing queries
+- See [Advanced Queries](../guides/queries.md) for complex examples
+- Read about [Transactions](../guides/transactions.md)

--- a/docs/concepts/repo.md
+++ b/docs/concepts/repo.md
@@ -1,0 +1,331 @@
+# Repository Pattern
+
+The Repo module is cquill's public API for all database operations. It provides a unified interface for executing queries against any adapter.
+
+## What is the Repo?
+
+The Repo is the single entry point for database I/O in cquill. It:
+
+- Executes queries against adapters
+- Manages transactions
+- Handles error conversion
+- Provides a consistent API across different backends
+
+```gleam
+import cquill/repo
+import cquill/adapter/memory
+
+// All database operations go through the repo
+let result = repo.all(adapter, query)
+let result = repo.one(adapter, query)
+let result = repo.insert(adapter, insert_query)
+let result = repo.update(adapter, update_query)
+let result = repo.delete(adapter, delete_query)
+```
+
+## Core Operations
+
+### Reading Data
+
+#### `repo.all` - Fetch Multiple Rows
+
+Returns all rows matching the query:
+
+```gleam
+import cquill/query
+import cquill/query/ast
+
+let query =
+  query.from("users")
+  |> query.where(query.eq("active", ast.BoolValue(True)))
+  |> query.order_by_asc("name")
+
+case repo.all(adapter, query) {
+  Ok(rows) -> {
+    // rows is List(Dict(String, ast.Value))
+    list.each(rows, fn(row) {
+      io.println("User: " <> string.inspect(row))
+    })
+  }
+  Error(e) -> handle_error(e)
+}
+```
+
+#### `repo.one` - Fetch Single Row
+
+Returns exactly one row, or an error:
+
+```gleam
+let query =
+  query.from("users")
+  |> query.where(query.eq("id", ast.IntValue(1)))
+
+case repo.one(adapter, query) {
+  Ok(row) -> {
+    // row is Dict(String, ast.Value)
+    io.println("Found user: " <> string.inspect(row))
+  }
+  Error(error.NotFound) -> {
+    io.println("User not found")
+  }
+  Error(error.TooManyRows(expected, got)) -> {
+    io.println("Expected 1 row, got " <> int.to_string(got))
+  }
+  Error(e) -> handle_error(e)
+}
+```
+
+#### `repo.exists` - Check Existence
+
+Returns whether any rows match:
+
+```gleam
+let query =
+  query.from("users")
+  |> query.where(query.eq("email", ast.StringValue("test@example.com")))
+
+case repo.exists(adapter, query) {
+  Ok(True) -> io.println("Email already taken")
+  Ok(False) -> io.println("Email available")
+  Error(e) -> handle_error(e)
+}
+```
+
+### Writing Data
+
+#### `repo.insert` - Create Records
+
+Insert new records:
+
+```gleam
+import cquill/query/ast
+
+let insert =
+  ast.new_insert("users")
+  |> ast.insert_columns(["email", "name"])
+  |> ast.insert_values([[
+    ast.StringValue("alice@example.com"),
+    ast.StringValue("Alice"),
+  ]])
+  |> ast.returning(["id"])
+
+case repo.insert(adapter, insert) {
+  Ok(rows) -> {
+    case list.first(rows) {
+      Ok(row) -> {
+        let id = dict.get(row, "id")
+        io.println("Created user with ID: " <> string.inspect(id))
+      }
+      Error(_) -> io.println("Insert succeeded but no rows returned")
+    }
+  }
+  Error(error.UniqueViolation(constraint, detail)) -> {
+    io.println("Email already exists")
+  }
+  Error(e) -> handle_error(e)
+}
+```
+
+#### `repo.insert_all` - Bulk Insert
+
+Insert multiple records efficiently:
+
+```gleam
+let users = [
+  [ast.StringValue("alice@example.com"), ast.StringValue("Alice")],
+  [ast.StringValue("bob@example.com"), ast.StringValue("Bob")],
+  [ast.StringValue("carol@example.com"), ast.StringValue("Carol")],
+]
+
+let insert =
+  ast.new_insert("users")
+  |> ast.insert_columns(["email", "name"])
+  |> ast.insert_values(users)
+
+case repo.insert_all(adapter, insert) {
+  Ok(count) -> io.println("Inserted " <> int.to_string(count) <> " users")
+  Error(e) -> handle_error(e)
+}
+```
+
+#### `repo.update` - Modify Records
+
+Update existing records:
+
+```gleam
+let update =
+  ast.new_update("users")
+  |> ast.set("name", ast.StringValue("Alice Smith"))
+  |> ast.update_where(query.eq("id", ast.IntValue(1)))
+  |> ast.returning(["id", "name"])
+
+case repo.update(adapter, update) {
+  Ok(rows) -> {
+    io.println("Updated " <> int.to_string(list.length(rows)) <> " rows")
+  }
+  Error(error.NotFound) -> {
+    io.println("No matching rows to update")
+  }
+  Error(e) -> handle_error(e)
+}
+```
+
+#### `repo.delete` - Remove Records
+
+Delete records:
+
+```gleam
+let delete =
+  ast.new_delete("users")
+  |> ast.delete_where(query.eq("id", ast.IntValue(1)))
+
+case repo.delete(adapter, delete) {
+  Ok(count) -> io.println("Deleted " <> int.to_string(count) <> " rows")
+  Error(e) -> handle_error(e)
+}
+```
+
+### Transactions
+
+#### `repo.transaction` - Atomic Operations
+
+Execute multiple operations atomically:
+
+```gleam
+repo.transaction(adapter, fn(tx) {
+  // All operations use the transaction context
+  use user <- result.try(repo.insert(tx, create_user))
+  use _profile <- result.try(repo.insert(tx, create_profile(user)))
+  use _settings <- result.try(repo.insert(tx, create_settings(user)))
+
+  Ok(user)
+})
+|> result.map(fn(user) {
+  io.println("Created user with profile and settings")
+})
+|> result.map_error(fn(e) {
+  io.println("Transaction failed, all changes rolled back")
+})
+```
+
+#### Savepoints
+
+For partial rollback within transactions:
+
+```gleam
+repo.transaction(adapter, fn(tx) {
+  use order <- result.try(repo.insert(tx, create_order))
+
+  // Create a savepoint
+  use sp <- repo.savepoint(tx, "process_items")
+
+  // Try to process items
+  case process_items(tx, order) {
+    Ok(items) -> Ok(#(order, items))
+    Error(_) -> {
+      // Roll back just the items, keep the order
+      repo.rollback_to_savepoint(tx, sp)
+      Ok(#(order, []))  // Order without items
+    }
+  }
+})
+```
+
+## Error Handling
+
+All repo operations return `Result` with specific error types:
+
+```gleam
+import cquill/error
+
+case repo.one(adapter, query) {
+  Ok(row) -> handle_success(row)
+
+  // Not found errors
+  Error(error.NotFound) -> handle_not_found()
+  Error(error.TooManyRows(expected, got)) -> handle_too_many()
+
+  // Connection errors
+  Error(error.ConnectionFailed(reason)) -> handle_connection_error()
+  Error(error.ConnectionTimeout) -> handle_timeout()
+  Error(error.PoolExhausted) -> handle_pool_exhausted()
+
+  // Query errors
+  Error(error.QueryFailed(message, code)) -> handle_query_error()
+  Error(error.Timeout) -> handle_query_timeout()
+
+  // Constraint violations
+  Error(error.UniqueViolation(constraint, detail)) -> handle_duplicate()
+  Error(error.ForeignKeyViolation(constraint, detail)) -> handle_fk_error()
+  Error(error.NotNullViolation(column)) -> handle_null_error()
+
+  // Catch-all
+  Error(e) -> handle_unknown_error(e)
+}
+```
+
+## Adapter Independence
+
+The repo works identically with different adapters:
+
+```gleam
+// Development/testing with memory adapter
+let dev_adapter = memory.new_store()
+let result = repo.all(dev_adapter, query)
+
+// Production with PostgreSQL adapter
+let prod_adapter = postgres.connect(config)
+let result = repo.all(prod_adapter, query)
+
+// Same query, same repo API, different backend
+```
+
+## Best Practices
+
+### 1. Use Transactions for Related Operations
+
+```gleam
+// Good: Atomic operation
+repo.transaction(adapter, fn(tx) {
+  use order <- result.try(repo.insert(tx, create_order))
+  use _ <- result.try(repo.update(tx, update_inventory))
+  Ok(order)
+})
+
+// Bad: Separate operations that should be atomic
+let order = repo.insert(adapter, create_order)  // What if this fails?
+let _ = repo.update(adapter, update_inventory)   // Inventory updated but order failed
+```
+
+### 2. Handle Specific Errors
+
+```gleam
+// Good: Handle specific cases
+case repo.insert(adapter, insert) {
+  Ok(row) -> Ok(row)
+  Error(error.UniqueViolation(_, _)) -> Error("Email already exists")
+  Error(e) -> Error("Unexpected error: " <> error.format(e))
+}
+
+// Bad: Generic error handling
+case repo.insert(adapter, insert) {
+  Ok(row) -> Ok(row)
+  Error(_) -> Error("Something went wrong")
+}
+```
+
+### 3. Use `one` vs `all` Appropriately
+
+```gleam
+// Use `one` when expecting exactly one result
+let user = repo.one(adapter, get_user_by_id(id))
+
+// Use `all` with limit(1) when you want at most one
+let user = repo.all(adapter, get_users() |> query.limit(1))
+```
+
+## Next Steps
+
+- Learn about [Adapters](./adapters.md) for backend specifics
+- See [Transactions](../guides/transactions.md) for advanced patterns
+- Read about [Error Handling](../reference/errors.md)

--- a/docs/concepts/schemas.md
+++ b/docs/concepts/schemas.md
@@ -1,0 +1,204 @@
+# Schemas
+
+Schemas in cquill describe the structure of your data. Unlike traditional ORMs where entities are tightly coupled to database tables, cquill schemas are metadata that describe fields, types, and relationships without performing any I/O.
+
+## What is a Schema?
+
+A schema is a description of a database table's structure:
+
+```gleam
+import cquill/schema
+import cquill/schema/field
+
+// Define a schema for the users table
+let user_schema =
+  schema.new("users")
+  |> schema.add_field(field.new("id", field.Integer) |> field.primary_key())
+  |> schema.add_field(field.new("email", field.String) |> field.not_null())
+  |> schema.add_field(field.new("name", field.String) |> field.nullable())
+  |> schema.add_field(field.new("active", field.Boolean) |> field.default("true"))
+  |> schema.add_field(field.new("created_at", field.Timestamp) |> field.not_null())
+```
+
+## Schema Components
+
+### Table Name
+
+Every schema has a table name that identifies the database table:
+
+```gleam
+let schema = schema.new("users")
+
+// With schema qualification
+let schema = schema.new_qualified("public", "users")
+```
+
+### Fields
+
+Fields describe columns in the table:
+
+```gleam
+import cquill/schema/field
+
+// Basic field
+field.new("email", field.String)
+
+// With constraints
+field.new("email", field.String)
+|> field.not_null()
+|> field.unique()
+
+// With default value
+field.new("active", field.Boolean)
+|> field.default("true")
+
+// Primary key
+field.new("id", field.Integer)
+|> field.primary_key()
+|> field.auto_increment()
+```
+
+### Field Types
+
+cquill supports common database field types:
+
+| Type | Gleam Type | Description |
+|------|------------|-------------|
+| `field.Integer` | `Int` | Integer values |
+| `field.BigInt` | `Int` | Large integer values |
+| `field.Float` | `Float` | Floating point numbers |
+| `field.Decimal(precision, scale)` | `Float` | Exact decimal numbers |
+| `field.String` | `String` | Text values |
+| `field.Text` | `String` | Long text values |
+| `field.Boolean` | `Bool` | True/false values |
+| `field.Timestamp` | Custom | Date and time |
+| `field.Date` | Custom | Date only |
+| `field.Time` | Custom | Time only |
+| `field.Uuid` | `String` | UUID values |
+| `field.Json` | `Dynamic` | JSON data |
+| `field.Jsonb` | `Dynamic` | Binary JSON (PostgreSQL) |
+
+### Constraints
+
+Apply constraints to fields:
+
+```gleam
+field.new("email", field.String)
+|> field.not_null()        // NOT NULL
+|> field.unique()          // UNIQUE
+|> field.primary_key()     // PRIMARY KEY
+|> field.check("length(email) > 5")  // CHECK constraint
+|> field.references("users", "id")   // FOREIGN KEY
+```
+
+## Multiple Schemas per Domain
+
+A key insight from Ecto is that you can have multiple schemas for the same data, each serving a different purpose:
+
+```gleam
+// Full user schema for reading
+let user_read_schema =
+  schema.new("users")
+  |> schema.add_field(field.new("id", field.Integer))
+  |> schema.add_field(field.new("email", field.String))
+  |> schema.add_field(field.new("name", field.String))
+  |> schema.add_field(field.new("password_hash", field.String))
+  |> schema.add_field(field.new("created_at", field.Timestamp))
+  |> schema.add_field(field.new("updated_at", field.Timestamp))
+
+// Minimal schema for inserting new users
+let user_insert_schema =
+  schema.new("users")
+  |> schema.add_field(field.new("email", field.String))
+  |> schema.add_field(field.new("name", field.String))
+  |> schema.add_field(field.new("password_hash", field.String))
+
+// Schema for public display (no sensitive fields)
+let user_public_schema =
+  schema.new("users")
+  |> schema.add_field(field.new("id", field.Integer))
+  |> schema.add_field(field.new("name", field.String))
+```
+
+## Schema Introspection
+
+You can inspect schemas at runtime:
+
+```gleam
+// Get table name
+schema.table_name(user_schema)  // "users"
+
+// Get all fields
+schema.fields(user_schema)  // List of Field records
+
+// Get a specific field
+schema.get_field(user_schema, "email")  // Option(Field)
+
+// Get primary key field(s)
+schema.primary_key_fields(user_schema)  // List of Field
+```
+
+## Generated Schemas
+
+For real-world usage, cquill can generate schemas from your database:
+
+```sh
+# Generate schemas from database introspection
+gleam run -m cquill_cli generate
+```
+
+This creates typed schema modules based on your actual database structure. See [Code Generation](../guides/codegen.md) for details.
+
+## Best Practices
+
+### 1. Keep Schemas Focused
+
+Create schemas that match specific use cases rather than one monolithic schema:
+
+```gleam
+// Good: Focused schemas
+let user_list_schema = ...  // For listing users
+let user_detail_schema = ...  // For user detail view
+let user_create_schema = ...  // For creating users
+
+// Avoid: One schema for everything
+let user_schema = ...  // Contains every field
+```
+
+### 2. Separate Read and Write Schemas
+
+Read operations often need different fields than write operations:
+
+```gleam
+// Read schema includes computed/joined fields
+let order_read_schema =
+  schema.new("orders")
+  |> schema.add_field(field.new("id", field.Integer))
+  |> schema.add_field(field.new("total", field.Decimal(10, 2)))
+  |> schema.add_field(field.new("customer_name", field.String))  // Joined
+
+// Write schema only includes writable fields
+let order_write_schema =
+  schema.new("orders")
+  |> schema.add_field(field.new("customer_id", field.Integer))
+  |> schema.add_field(field.new("total", field.Decimal(10, 2)))
+```
+
+### 3. Use Schema for Validation Context
+
+Schemas provide context for validation:
+
+```gleam
+// Validate that all required fields are present
+fn validate_for_insert(data, schema) {
+  schema.fields(schema)
+  |> list.filter(fn(f) { field.is_required(f) })
+  |> list.all(fn(f) { dict.has_key(data, field.name(f)) })
+}
+```
+
+## Next Steps
+
+- Learn about [Queries](./queries.md) to query your schemas
+- See [Repo](./repo.md) for executing queries
+- Read about [Adapters](./adapters.md) for backend abstraction

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,204 @@
+# Getting Started with cquill
+
+This guide will help you get cquill installed and running your first database query.
+
+## Installation
+
+Add cquill to your Gleam project:
+
+```sh
+gleam add cquill
+```
+
+For PostgreSQL support, you'll also need the pgo driver:
+
+```sh
+gleam add pgo
+```
+
+## Your First Query
+
+Here's a complete example showing how to query a PostgreSQL database:
+
+```gleam
+import cquill/adapter/memory
+import cquill/query
+import cquill/query/ast
+import cquill/repo
+import gleam/dict
+import gleam/io
+import gleam/option.{None, Some}
+
+pub fn main() {
+  // Create an in-memory store for testing
+  let store = memory.new_store()
+
+  // Create a table
+  let store = memory.create_table(store, "users", ["id", "email", "name", "active"])
+
+  // Insert some data
+  let store = memory.insert_row(store, "users", dict.from_list([
+    #("id", ast.IntValue(1)),
+    #("email", ast.StringValue("alice@example.com")),
+    #("name", ast.StringValue("Alice")),
+    #("active", ast.BoolValue(True)),
+  ]))
+
+  let store = memory.insert_row(store, "users", dict.from_list([
+    #("id", ast.IntValue(2)),
+    #("email", ast.StringValue("bob@example.com")),
+    #("name", ast.StringValue("Bob")),
+    #("active", ast.BoolValue(False)),
+  ]))
+
+  // Build a query for active users
+  let active_users_query =
+    query.from("users")
+    |> query.where(query.eq("active", ast.BoolValue(True)))
+    |> query.select(["id", "email", "name"])
+    |> query.order_by_asc("email")
+
+  // Execute the query
+  case memory.execute_select(store, active_users_query) {
+    Ok(rows) -> {
+      io.println("Found " <> int.to_string(list.length(rows)) <> " active users:")
+      list.each(rows, fn(row) {
+        io.println("  - " <> string.inspect(row))
+      })
+    }
+    Error(e) -> {
+      io.println_error("Query failed: " <> string.inspect(e))
+    }
+  }
+}
+```
+
+## Key Concepts
+
+### 1. Queries are Data
+
+In cquill, queries are represented as data structures (ASTs), not strings. This enables:
+
+- **Type safety** - Invalid queries fail at compile time
+- **Composition** - Build complex queries from simple parts
+- **Inspection** - Debug and log queries easily
+
+```gleam
+// Queries can be composed
+let base_query = query.from("users")
+
+let active_query = base_query
+  |> query.where(query.eq("active", ast.BoolValue(True)))
+
+let admin_query = base_query
+  |> query.where(query.eq("role", ast.StringValue("admin")))
+```
+
+### 2. Adapters Abstract the Backend
+
+The same query works with different backends:
+
+```gleam
+// In-memory adapter for testing
+let result = memory.execute_select(store, my_query)
+
+// PostgreSQL adapter for production (when implemented)
+// let result = postgres.execute_select(pool, my_query)
+```
+
+### 3. Explicit Error Handling
+
+All operations return `Result` types with specific error information:
+
+```gleam
+case memory.execute_select(store, query) {
+  Ok(rows) -> handle_success(rows)
+  Error(error.NotFound) -> handle_not_found()
+  Error(error.QueryFailed(msg, code)) -> handle_query_error(msg)
+  Error(e) -> handle_other_error(e)
+}
+```
+
+## Next Steps
+
+- Read about [Schemas](./concepts/schemas.md) to understand how cquill describes your data
+- Learn [Query Building](./concepts/queries.md) for more complex queries
+- See [CRUD Operations](./guides/crud.md) for common data operations
+- Check out [Testing](./guides/testing.md) for testing strategies
+
+## Quick Reference
+
+### Query Building
+
+```gleam
+import cquill/query
+import cquill/query/ast
+
+// SELECT
+query.from("users")
+|> query.select(["id", "email"])
+|> query.select_all()  // SELECT *
+
+// WHERE
+|> query.where(query.eq("id", ast.IntValue(1)))
+|> query.where(query.gt("age", ast.IntValue(18)))
+|> query.where(query.like("name", "%smith%"))
+|> query.where(query.is_null("deleted_at"))
+
+// ORDER BY
+|> query.order_by_asc("created_at")
+|> query.order_by_desc("updated_at")
+
+// LIMIT / OFFSET
+|> query.limit(10)
+|> query.offset(20)
+
+// DISTINCT
+|> query.distinct()
+```
+
+### Conditions
+
+```gleam
+// Equality
+query.eq("field", value)
+query.not_eq("field", value)
+
+// Comparison
+query.gt("field", value)   // >
+query.gte("field", value)  // >=
+query.lt("field", value)   // <
+query.lte("field", value)  // <=
+
+// Pattern matching
+query.like("field", "%pattern%")
+query.ilike("field", "%pattern%")  // Case insensitive
+
+// NULL checks
+query.is_null("field")
+query.is_not_null("field")
+
+// IN
+query.in_list("field", [value1, value2])
+
+// BETWEEN
+query.between("field", low, high)
+
+// Logical operators
+query.and_where([cond1, cond2])
+query.or_where([cond1, cond2])
+query.not_where(condition)
+```
+
+### Value Types
+
+```gleam
+import cquill/query/ast
+
+ast.IntValue(42)
+ast.FloatValue(3.14)
+ast.StringValue("hello")
+ast.BoolValue(True)
+ast.NullValue
+ast.ListValue([ast.IntValue(1), ast.IntValue(2)])
+```

--- a/docs/guides/crud.md
+++ b/docs/guides/crud.md
@@ -1,0 +1,405 @@
+# CRUD Operations
+
+This guide covers the fundamental Create, Read, Update, and Delete operations in cquill.
+
+## Create (INSERT)
+
+### Single Record Insert
+
+```gleam
+import cquill/query/ast
+import cquill/repo
+
+let insert =
+  ast.new_insert("users")
+  |> ast.insert_columns(["email", "name", "active"])
+  |> ast.insert_values([[
+    ast.StringValue("alice@example.com"),
+    ast.StringValue("Alice"),
+    ast.BoolValue(True),
+  ]])
+  |> ast.returning(["id", "created_at"])
+
+case repo.insert(adapter, insert) {
+  Ok(rows) -> {
+    // rows contains the RETURNING data
+    case list.first(rows) {
+      Ok(row) -> {
+        let id = dict.get(row, "id")
+        io.println("Created user with ID: " <> string.inspect(id))
+      }
+      Error(_) -> io.println("Insert succeeded")
+    }
+  }
+  Error(error.UniqueViolation(constraint, _)) -> {
+    io.println("Duplicate value: " <> constraint)
+  }
+  Error(error.NotNullViolation(column)) -> {
+    io.println("Missing required field: " <> column)
+  }
+  Error(e) -> {
+    io.println("Insert failed: " <> error.format(e))
+  }
+}
+```
+
+### Bulk Insert
+
+Insert multiple records in a single operation:
+
+```gleam
+let users = [
+  [ast.StringValue("alice@example.com"), ast.StringValue("Alice")],
+  [ast.StringValue("bob@example.com"), ast.StringValue("Bob")],
+  [ast.StringValue("carol@example.com"), ast.StringValue("Carol")],
+]
+
+let insert =
+  ast.new_insert("users")
+  |> ast.insert_columns(["email", "name"])
+  |> ast.insert_values(users)
+
+case repo.insert_all(adapter, insert) {
+  Ok(count) -> io.println("Inserted " <> int.to_string(count) <> " users")
+  Error(e) -> io.println("Bulk insert failed: " <> error.format(e))
+}
+```
+
+### Insert with ON CONFLICT (Upsert)
+
+Handle conflicts gracefully:
+
+```gleam
+// ON CONFLICT DO NOTHING
+let insert =
+  ast.new_insert("users")
+  |> ast.insert_columns(["email", "name"])
+  |> ast.insert_values([[
+    ast.StringValue("alice@example.com"),
+    ast.StringValue("Alice"),
+  ]])
+  |> ast.on_conflict(ast.DoNothing)
+
+// ON CONFLICT DO UPDATE
+let upsert =
+  ast.new_insert("users")
+  |> ast.insert_columns(["email", "name"])
+  |> ast.insert_values([[
+    ast.StringValue("alice@example.com"),
+    ast.StringValue("Alice Updated"),
+  ]])
+  |> ast.on_conflict(ast.DoUpdate(
+    conflict_columns: ["email"],
+    update_columns: ["name"],
+  ))
+```
+
+## Read (SELECT)
+
+### Fetch All Records
+
+```gleam
+import cquill/query
+import cquill/repo
+
+let users_query = query.from("users")
+
+case repo.all(adapter, users_query) {
+  Ok(rows) -> {
+    list.each(rows, fn(row) {
+      let email = dict.get(row, "email")
+      io.println("User: " <> string.inspect(email))
+    })
+  }
+  Error(e) -> io.println("Query failed: " <> error.format(e))
+}
+```
+
+### Fetch Single Record
+
+```gleam
+let user_query =
+  query.from("users")
+  |> query.where(query.eq("id", ast.IntValue(1)))
+
+case repo.one(adapter, user_query) {
+  Ok(row) -> {
+    let name = dict.get(row, "name")
+    io.println("Found: " <> string.inspect(name))
+  }
+  Error(error.NotFound) -> {
+    io.println("User not found")
+  }
+  Error(error.TooManyRows(expected, got)) -> {
+    io.println("Expected 1, found " <> int.to_string(got))
+  }
+  Error(e) -> io.println("Query failed: " <> error.format(e))
+}
+```
+
+### Filtered Queries
+
+```gleam
+// Active users only
+let active_users =
+  query.from("users")
+  |> query.where(query.eq("active", ast.BoolValue(True)))
+
+// Users by role
+let admins =
+  query.from("users")
+  |> query.where(query.eq("role", ast.StringValue("admin")))
+
+// Combined filters
+let active_admins =
+  query.from("users")
+  |> query.where(query.eq("active", ast.BoolValue(True)))
+  |> query.where(query.eq("role", ast.StringValue("admin")))
+
+// OR conditions
+let special_users =
+  query.from("users")
+  |> query.where(query.or_where([
+    query.eq("role", ast.StringValue("admin")),
+    query.eq("role", ast.StringValue("moderator")),
+  ]))
+```
+
+### Sorted and Limited Queries
+
+```gleam
+// Newest first, limit 10
+let recent_users =
+  query.from("users")
+  |> query.order_by_desc("created_at")
+  |> query.limit(10)
+
+// Paginated
+let page_2 =
+  query.from("users")
+  |> query.order_by_asc("id")
+  |> query.limit(20)
+  |> query.offset(20)  // Skip first 20
+```
+
+### Select Specific Columns
+
+```gleam
+// Only fetch needed columns
+let user_names =
+  query.from("users")
+  |> query.select(["id", "name"])
+  |> query.where(query.eq("active", ast.BoolValue(True)))
+```
+
+## Update
+
+### Update Single Record
+
+```gleam
+import cquill/query/ast
+
+let update =
+  ast.new_update("users")
+  |> ast.set("name", ast.StringValue("Alice Smith"))
+  |> ast.set("updated_at", ast.StringValue("2024-01-15T10:00:00Z"))
+  |> ast.update_where(query.eq("id", ast.IntValue(1)))
+  |> ast.returning(["id", "name", "updated_at"])
+
+case repo.update(adapter, update) {
+  Ok(rows) -> {
+    case list.first(rows) {
+      Ok(row) -> io.println("Updated: " <> string.inspect(row))
+      Error(_) -> io.println("Update succeeded, no return data")
+    }
+  }
+  Error(error.NotFound) -> {
+    io.println("No matching record to update")
+  }
+  Error(e) -> io.println("Update failed: " <> error.format(e))
+}
+```
+
+### Update Multiple Records
+
+```gleam
+// Deactivate all inactive users older than 90 days
+let update =
+  ast.new_update("users")
+  |> ast.set("active", ast.BoolValue(False))
+  |> ast.update_where(query.and_where([
+    query.eq("active", ast.BoolValue(True)),
+    query.lt("last_login", ast.StringValue("2024-01-01")),
+  ]))
+
+case repo.update(adapter, update) {
+  Ok(rows) -> {
+    io.println("Deactivated " <> int.to_string(list.length(rows)) <> " users")
+  }
+  Error(e) -> io.println("Update failed: " <> error.format(e))
+}
+```
+
+### Conditional Updates
+
+```gleam
+// Only update if version matches (optimistic locking)
+let update =
+  ast.new_update("posts")
+  |> ast.set("title", ast.StringValue("New Title"))
+  |> ast.set("version", ast.IntValue(2))
+  |> ast.update_where(query.and_where([
+    query.eq("id", ast.IntValue(post_id)),
+    query.eq("version", ast.IntValue(1)),  // Expected version
+  ]))
+  |> ast.returning(["id", "version"])
+
+case repo.update(adapter, update) {
+  Ok([]) -> {
+    // No rows updated - version mismatch
+    Error(error.StaleData("1", "unknown"))
+  }
+  Ok(rows) -> Ok(rows)
+  Error(e) -> Error(e)
+}
+```
+
+## Delete
+
+### Delete Single Record
+
+```gleam
+let delete =
+  ast.new_delete("users")
+  |> ast.delete_where(query.eq("id", ast.IntValue(1)))
+  |> ast.returning(["id", "email"])
+
+case repo.delete(adapter, delete) {
+  Ok(count) when count > 0 -> {
+    io.println("Deleted user")
+  }
+  Ok(_) -> {
+    io.println("No user found to delete")
+  }
+  Error(error.ForeignKeyViolation(constraint, _)) -> {
+    io.println("Cannot delete: referenced by other records")
+  }
+  Error(e) -> io.println("Delete failed: " <> error.format(e))
+}
+```
+
+### Delete Multiple Records
+
+```gleam
+// Delete old sessions
+let delete =
+  ast.new_delete("sessions")
+  |> ast.delete_where(query.lt("expires_at", ast.StringValue("2024-01-01")))
+
+case repo.delete(adapter, delete) {
+  Ok(count) -> {
+    io.println("Deleted " <> int.to_string(count) <> " expired sessions")
+  }
+  Error(e) -> io.println("Delete failed: " <> error.format(e))
+}
+```
+
+### Delete All Records (Truncate)
+
+```gleam
+// WARNING: Deletes all records in table
+let delete_all =
+  ast.new_delete("temp_data")
+  // No where clause = delete all
+
+case repo.delete(adapter, delete_all) {
+  Ok(count) -> io.println("Cleared " <> int.to_string(count) <> " records")
+  Error(e) -> io.println("Delete failed: " <> error.format(e))
+}
+```
+
+## Transactions
+
+Wrap related operations in a transaction:
+
+```gleam
+repo.transaction(adapter, fn(tx) {
+  // Create user
+  use user_rows <- result.try(repo.insert(tx, create_user))
+  let user_id = get_id(user_rows)
+
+  // Create profile with user_id
+  let profile_insert = create_profile_insert(user_id)
+  use _ <- result.try(repo.insert(tx, profile_insert))
+
+  // Return success
+  Ok(user_id)
+})
+```
+
+## Helper Functions
+
+Create reusable CRUD functions:
+
+```gleam
+// Generic insert helper
+pub fn insert_one(adapter, table: String, data: Dict(String, ast.Value)) {
+  let columns = dict.keys(data)
+  let values = dict.values(data) |> list.map(fn(v) { [v] })
+
+  let insert =
+    ast.new_insert(table)
+    |> ast.insert_columns(columns)
+    |> ast.insert_values(values)
+    |> ast.returning(["id"])
+
+  repo.insert(adapter, insert)
+  |> result.map(fn(rows) {
+    case list.first(rows) {
+      Ok(row) -> dict.get(row, "id")
+      Error(_) -> Error(Nil)
+    }
+  })
+}
+
+// Generic find by ID
+pub fn find_by_id(adapter, table: String, id: Int) {
+  let query =
+    query.from(table)
+    |> query.where(query.eq("id", ast.IntValue(id)))
+
+  repo.one(adapter, query)
+}
+
+// Generic update by ID
+pub fn update_by_id(
+  adapter,
+  table: String,
+  id: Int,
+  updates: List(#(String, ast.Value)),
+) {
+  let update =
+    list.fold(updates, ast.new_update(table), fn(q, pair) {
+      let #(column, value) = pair
+      ast.set(q, column, value)
+    })
+    |> ast.update_where(query.eq("id", ast.IntValue(id)))
+
+  repo.update(adapter, update)
+}
+
+// Generic delete by ID
+pub fn delete_by_id(adapter, table: String, id: Int) {
+  let delete =
+    ast.new_delete(table)
+    |> ast.delete_where(query.eq("id", ast.IntValue(id)))
+
+  repo.delete(adapter, delete)
+}
+```
+
+## Next Steps
+
+- Learn about [Advanced Queries](./queries.md) for complex operations
+- See [Transactions](./transactions.md) for atomic operations
+- Read about [Error Handling](../reference/errors.md)

--- a/docs/guides/queries.md
+++ b/docs/guides/queries.md
@@ -1,0 +1,445 @@
+# Advanced Queries
+
+This guide covers advanced query patterns in cquill including joins, aggregations, subqueries, and complex conditions.
+
+## Complex WHERE Conditions
+
+### Combining AND and OR
+
+```gleam
+import cquill/query
+import cquill/query/ast
+
+// (active = true) AND (role = 'admin' OR role = 'moderator')
+let query =
+  query.from("users")
+  |> query.where(query.eq("active", ast.BoolValue(True)))
+  |> query.where(query.or_where([
+    query.eq("role", ast.StringValue("admin")),
+    query.eq("role", ast.StringValue("moderator")),
+  ]))
+
+// (status = 'pending') AND ((priority = 'high') OR (created_at < '2024-01-01'))
+let urgent_tasks =
+  query.from("tasks")
+  |> query.where(query.eq("status", ast.StringValue("pending")))
+  |> query.where(query.or_where([
+    query.eq("priority", ast.StringValue("high")),
+    query.lt("created_at", ast.StringValue("2024-01-01")),
+  ]))
+```
+
+### Negation
+
+```gleam
+// NOT (status = 'deleted')
+let active_items =
+  query.from("items")
+  |> query.where(query.not_where(query.eq("status", ast.StringValue("deleted"))))
+
+// NOT (role = 'guest' AND verified = false)
+let trusted_users =
+  query.from("users")
+  |> query.where(query.not_where(query.and_where([
+    query.eq("role", ast.StringValue("guest")),
+    query.eq("verified", ast.BoolValue(False)),
+  ])))
+```
+
+### IN and NOT IN
+
+```gleam
+// status IN ('active', 'pending', 'review')
+let query =
+  query.from("orders")
+  |> query.where(query.in_list("status", [
+    ast.StringValue("active"),
+    ast.StringValue("pending"),
+    ast.StringValue("review"),
+  ]))
+
+// category_id NOT IN (1, 2, 3)
+let query =
+  query.from("products")
+  |> query.where(query.not_in_list("category_id", [
+    ast.IntValue(1),
+    ast.IntValue(2),
+    ast.IntValue(3),
+  ]))
+```
+
+### BETWEEN
+
+```gleam
+// price BETWEEN 10 AND 100
+let query =
+  query.from("products")
+  |> query.where(query.between(
+    "price",
+    ast.FloatValue(10.0),
+    ast.FloatValue(100.0),
+  ))
+
+// created_at BETWEEN '2024-01-01' AND '2024-12-31'
+let query =
+  query.from("orders")
+  |> query.where(query.between(
+    "created_at",
+    ast.StringValue("2024-01-01"),
+    ast.StringValue("2024-12-31"),
+  ))
+```
+
+### Pattern Matching
+
+```gleam
+// LIKE patterns
+let query =
+  query.from("users")
+  |> query.where(query.like("email", "%@gmail.com"))  // Ends with
+  |> query.where(query.like("name", "John%"))         // Starts with
+  |> query.where(query.like("bio", "%developer%"))    // Contains
+
+// Case-insensitive ILIKE
+let query =
+  query.from("products")
+  |> query.where(query.ilike("name", "%phone%"))
+
+// NOT LIKE
+let query =
+  query.from("users")
+  |> query.where(query.not_like("email", "%@test.com"))
+```
+
+## JOINs
+
+### Inner Join
+
+```gleam
+// Get orders with customer information
+let query =
+  query.from("orders")
+  |> query.inner_join("customers",
+    query.raw_condition("orders.customer_id = customers.id"))
+  |> query.select([
+    "orders.id",
+    "orders.total",
+    "customers.name",
+    "customers.email",
+  ])
+```
+
+### Left Join
+
+```gleam
+// Get all users with their optional profile
+let query =
+  query.from("users")
+  |> query.left_join("profiles",
+    query.raw_condition("users.id = profiles.user_id"))
+  |> query.select([
+    "users.id",
+    "users.email",
+    "profiles.bio",
+    "profiles.avatar_url",
+  ])
+```
+
+### Multiple Joins
+
+```gleam
+// Orders with customer and product details
+let query =
+  query.from("orders")
+  |> query.inner_join("customers",
+    query.raw_condition("orders.customer_id = customers.id"))
+  |> query.inner_join("order_items",
+    query.raw_condition("orders.id = order_items.order_id"))
+  |> query.inner_join("products",
+    query.raw_condition("order_items.product_id = products.id"))
+  |> query.select([
+    "orders.id",
+    "customers.name",
+    "products.title",
+    "order_items.quantity",
+  ])
+```
+
+### Self Join
+
+```gleam
+// Employees with their managers
+let query =
+  query.from("employees")
+  |> query.left_join_as("employees", "managers",
+    query.raw_condition("employees.manager_id = managers.id"))
+  |> query.select([
+    "employees.name AS employee_name",
+    "managers.name AS manager_name",
+  ])
+```
+
+## Aggregations
+
+### COUNT
+
+```gleam
+// Count all users
+let query =
+  query.from("users")
+  |> query.select_expr([ast.AggregateExpr(ast.Count, "*")])
+
+// Count active users
+let query =
+  query.from("users")
+  |> query.where(query.eq("active", ast.BoolValue(True)))
+  |> query.select_expr([ast.AggregateExpr(ast.Count, "id")])
+```
+
+### SUM, AVG, MIN, MAX
+
+```gleam
+// Total revenue
+let query =
+  query.from("orders")
+  |> query.select_expr([ast.AggregateExpr(ast.Sum, "total")])
+
+// Average order value
+let query =
+  query.from("orders")
+  |> query.select_expr([ast.AggregateExpr(ast.Avg, "total")])
+
+// Price range
+let query =
+  query.from("products")
+  |> query.select_expr([
+    ast.AggregateExpr(ast.Min, "price"),
+    ast.AggregateExpr(ast.Max, "price"),
+  ])
+```
+
+### GROUP BY
+
+```gleam
+// Orders per customer
+let query =
+  query.from("orders")
+  |> query.select_expr([
+    ast.ColumnExpr("customer_id"),
+    ast.AggregateExpr(ast.Count, "id"),
+    ast.AggregateExpr(ast.Sum, "total"),
+  ])
+  |> query.group_by(["customer_id"])
+
+// Sales by month
+let query =
+  query.from("orders")
+  |> query.select_expr([
+    ast.FunctionExpr("date_trunc", [
+      ast.LiteralExpr(ast.StringValue("month")),
+      ast.ColumnExpr("created_at"),
+    ]),
+    ast.AggregateExpr(ast.Sum, "total"),
+  ])
+  |> query.group_by(["date_trunc('month', created_at)"])
+```
+
+### HAVING
+
+```gleam
+// Customers with more than 5 orders
+let query =
+  query.from("orders")
+  |> query.select_expr([
+    ast.ColumnExpr("customer_id"),
+    ast.AggregateExpr(ast.Count, "id"),
+  ])
+  |> query.group_by(["customer_id"])
+  |> query.having(query.gt("count", ast.IntValue(5)))
+
+// Categories with high average price
+let query =
+  query.from("products")
+  |> query.select_expr([
+    ast.ColumnExpr("category_id"),
+    ast.AggregateExpr(ast.Avg, "price"),
+  ])
+  |> query.group_by(["category_id"])
+  |> query.having(query.gt("avg", ast.FloatValue(100.0)))
+```
+
+## Subqueries
+
+### IN Subquery
+
+```gleam
+// Users who have placed orders
+let orders_subquery =
+  query.from("orders")
+  |> query.select(["customer_id"])
+  |> query.distinct()
+
+let query =
+  query.from("users")
+  |> query.where(query.in_subquery("id", orders_subquery))
+```
+
+### Correlated Subquery
+
+```gleam
+// Products with above-average price in their category
+let query =
+  query.from("products")
+  |> query.where(query.raw(
+    "price > (SELECT AVG(price) FROM products p2 WHERE p2.category_id = products.category_id)",
+    [],
+  ))
+```
+
+## Raw SQL
+
+For queries that can't be expressed with the builder:
+
+```gleam
+// Raw condition
+let query =
+  query.from("users")
+  |> query.where(query.raw("age > $1 AND verified = $2", [
+    ast.IntValue(18),
+    ast.BoolValue(True),
+  ]))
+
+// Complex expression
+let query =
+  query.from("products")
+  |> query.where(query.raw(
+    "price * quantity > $1",
+    [ast.FloatValue(1000.0)],
+  ))
+```
+
+## Query Composition
+
+### Reusable Query Parts
+
+```gleam
+// Base query builder
+fn base_products_query() {
+  query.from("products")
+  |> query.where(query.eq("active", ast.BoolValue(True)))
+  |> query.where(query.is_null("deleted_at"))
+}
+
+// Add category filter
+fn in_category(q, category_id: Int) {
+  q |> query.where(query.eq("category_id", ast.IntValue(category_id)))
+}
+
+// Add price range
+fn price_range(q, min: Float, max: Float) {
+  q
+  |> query.where(query.gte("price", ast.FloatValue(min)))
+  |> query.where(query.lte("price", ast.FloatValue(max)))
+}
+
+// Add search
+fn search_name(q, term: String) {
+  q |> query.where(query.ilike("name", "%" <> term <> "%"))
+}
+
+// Combine them
+let affordable_electronics =
+  base_products_query()
+  |> in_category(1)
+  |> price_range(0.0, 100.0)
+  |> search_name("phone")
+```
+
+### Conditional Query Building
+
+```gleam
+pub type ProductFilters {
+  ProductFilters(
+    category_id: Option(Int),
+    min_price: Option(Float),
+    max_price: Option(Float),
+    search: Option(String),
+    in_stock: Option(Bool),
+  )
+}
+
+pub fn build_product_query(filters: ProductFilters) {
+  query.from("products")
+  |> apply_if(filters.category_id, fn(q, cat_id) {
+    query.where(q, query.eq("category_id", ast.IntValue(cat_id)))
+  })
+  |> apply_if(filters.min_price, fn(q, min) {
+    query.where(q, query.gte("price", ast.FloatValue(min)))
+  })
+  |> apply_if(filters.max_price, fn(q, max) {
+    query.where(q, query.lte("price", ast.FloatValue(max)))
+  })
+  |> apply_if(filters.search, fn(q, term) {
+    query.where(q, query.ilike("name", "%" <> term <> "%"))
+  })
+  |> apply_if(filters.in_stock, fn(q, in_stock) {
+    query.where(q, query.gt("stock_count", ast.IntValue(0)))
+  })
+}
+
+fn apply_if(q, option: Option(a), f: fn(Query, a) -> Query) -> Query {
+  case option {
+    Some(value) -> f(q, value)
+    None -> q
+  }
+}
+```
+
+## Performance Considerations
+
+### Select Only Needed Columns
+
+```gleam
+// Good: Select only what you need
+let query =
+  query.from("users")
+  |> query.select(["id", "name", "email"])
+
+// Avoid: Fetching all columns when you don't need them
+let query =
+  query.from("users")
+  |> query.select_all()  // Fetches all columns including blobs
+```
+
+### Use Indexes
+
+```gleam
+// Good: Filter on indexed columns first
+let query =
+  query.from("orders")
+  |> query.where(query.eq("customer_id", ast.IntValue(1)))  // Indexed
+  |> query.where(query.gte("total", ast.FloatValue(100.0)))
+
+// Consider: Add index for frequently filtered columns
+// CREATE INDEX idx_orders_customer_id ON orders(customer_id);
+```
+
+### Limit Results
+
+```gleam
+// Good: Always limit when you don't need all results
+let query =
+  query.from("logs")
+  |> query.order_by_desc("created_at")
+  |> query.limit(100)
+
+// Avoid: Fetching unlimited results
+let query =
+  query.from("logs")  // Could be millions of rows
+```
+
+## Next Steps
+
+- See [Transactions](./transactions.md) for atomic operations
+- Read about [Testing](./testing.md) your queries
+- Check [Pagination recipes](../recipes/pagination.md)

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -1,0 +1,538 @@
+# Testing with cquill
+
+This guide covers testing strategies for applications using cquill, from unit tests to integration tests.
+
+## Testing Philosophy
+
+cquill encourages a layered testing approach:
+
+```
+┌────────────────────────────────────┐
+│  Ring 3: System/Integration Tests  │  Real database, full flows
+├────────────────────────────────────┤
+│  Ring 2: Adapter Contract Tests    │  Verify adapter behavior
+├────────────────────────────────────┤
+│  Ring 1: Unit Tests (Pure Code)    │  No I/O, fast, isolated
+└────────────────────────────────────┘
+```
+
+## Ring 1: Unit Tests (Pure Code)
+
+Test pure functions without any database:
+
+### Testing Query Builders
+
+```gleam
+import gleeunit/should
+import cquill/query
+import cquill/query/ast
+
+pub fn query_builder_creates_correct_ast_test() {
+  let q =
+    query.from("users")
+    |> query.where(query.eq("active", ast.BoolValue(True)))
+    |> query.order_by_asc("name")
+    |> query.limit(10)
+
+  // Verify the AST structure
+  case q.source {
+    ast.TableSource(table, _) -> table |> should.equal("users")
+    _ -> should.fail()
+  }
+
+  q.wheres |> list.length() |> should.equal(1)
+  q.order_bys |> list.length() |> should.equal(1)
+  q.limit |> should.equal(Some(10))
+}
+
+pub fn where_conditions_compose_correctly_test() {
+  let q =
+    query.from("users")
+    |> query.where(query.eq("a", ast.IntValue(1)))
+    |> query.where(query.eq("b", ast.IntValue(2)))
+
+  // Both conditions are added
+  q.wheres |> list.length() |> should.equal(2)
+}
+```
+
+### Testing Business Logic
+
+```gleam
+import cquill/query/ast
+
+// Business logic that builds queries
+pub fn build_user_search_query(
+  search_term: Option(String),
+  active_only: Bool,
+  page: Int,
+  per_page: Int,
+) {
+  query.from("users")
+  |> apply_search(search_term)
+  |> apply_active_filter(active_only)
+  |> query.order_by_asc("name")
+  |> query.limit(per_page)
+  |> query.offset((page - 1) * per_page)
+}
+
+// Tests
+pub fn search_query_applies_search_term_test() {
+  let q = build_user_search_query(Some("john"), False, 1, 20)
+
+  // Check that search condition was added
+  q.wheres |> list.length() |> should.equal(1)
+}
+
+pub fn search_query_applies_pagination_test() {
+  let q = build_user_search_query(None, False, 3, 20)
+
+  q.limit |> should.equal(Some(20))
+  q.offset |> should.equal(Some(40))  // (3-1) * 20
+}
+
+pub fn search_query_filters_active_when_requested_test() {
+  let q = build_user_search_query(None, True, 1, 20)
+
+  q.wheres |> list.length() |> should.equal(1)
+}
+```
+
+### Testing Validation Logic
+
+```gleam
+pub type UserInput {
+  UserInput(email: String, name: String, age: Int)
+}
+
+pub type ValidationError {
+  InvalidEmail
+  NameTooShort
+  AgeTooYoung
+}
+
+pub fn validate_user_input(input: UserInput) -> Result(UserInput, List(ValidationError)) {
+  let errors = []
+  let errors = case string.contains(input.email, "@") {
+    True -> errors
+    False -> [InvalidEmail, ..errors]
+  }
+  let errors = case string.length(input.name) >= 2 {
+    True -> errors
+    False -> [NameTooShort, ..errors]
+  }
+  let errors = case input.age >= 18 {
+    True -> errors
+    False -> [AgeTooYoung, ..errors]
+  }
+
+  case errors {
+    [] -> Ok(input)
+    _ -> Error(errors)
+  }
+}
+
+// Tests
+pub fn validate_accepts_valid_input_test() {
+  let input = UserInput("test@example.com", "Alice", 25)
+  validate_user_input(input) |> should.be_ok()
+}
+
+pub fn validate_rejects_invalid_email_test() {
+  let input = UserInput("invalid", "Alice", 25)
+  case validate_user_input(input) {
+    Error(errors) -> errors |> should.equal([InvalidEmail])
+    Ok(_) -> should.fail()
+  }
+}
+
+pub fn validate_collects_multiple_errors_test() {
+  let input = UserInput("invalid", "A", 10)
+  case validate_user_input(input) {
+    Error(errors) -> list.length(errors) |> should.equal(3)
+    Ok(_) -> should.fail()
+  }
+}
+```
+
+## Ring 2: Adapter Tests with Memory Adapter
+
+Test database operations using the memory adapter:
+
+### Basic CRUD Tests
+
+```gleam
+import cquill/adapter/memory
+import cquill/query
+import cquill/query/ast
+
+pub fn memory_adapter_insert_and_select_test() {
+  // Setup
+  let store = memory.new_store()
+    |> memory.create_table("users", ["id", "email", "name"])
+
+  // Insert
+  let store = memory.insert_row(store, "users", dict.from_list([
+    #("id", ast.IntValue(1)),
+    #("email", ast.StringValue("alice@example.com")),
+    #("name", ast.StringValue("Alice")),
+  ]))
+
+  // Query
+  let query = query.from("users")
+    |> query.where(query.eq("id", ast.IntValue(1)))
+
+  // Assert
+  case memory.execute_select(store, query) {
+    Ok(rows) -> {
+      list.length(rows) |> should.equal(1)
+      case list.first(rows) {
+        Ok(row) -> {
+          dict.get(row, "email")
+          |> should.equal(Ok(ast.StringValue("alice@example.com")))
+        }
+        Error(_) -> should.fail()
+      }
+    }
+    Error(_) -> should.fail()
+  }
+}
+
+pub fn memory_adapter_update_test() {
+  let store = memory.new_store()
+    |> memory.create_table("users", ["id", "name"])
+    |> memory.insert_row("users", dict.from_list([
+      #("id", ast.IntValue(1)),
+      #("name", ast.StringValue("Alice")),
+    ]))
+
+  let update = ast.new_update("users")
+    |> ast.set("name", ast.StringValue("Alice Smith"))
+    |> ast.update_where(query.eq("id", ast.IntValue(1)))
+
+  let store = case memory.execute_update(store, update) {
+    Ok(#(new_store, _)) -> new_store
+    Error(_) -> { should.fail() store }
+  }
+
+  // Verify update
+  let query = query.from("users")
+    |> query.where(query.eq("id", ast.IntValue(1)))
+
+  case memory.execute_select(store, query) {
+    Ok([row]) -> {
+      dict.get(row, "name")
+      |> should.equal(Ok(ast.StringValue("Alice Smith")))
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn memory_adapter_delete_test() {
+  let store = memory.new_store()
+    |> memory.create_table("users", ["id"])
+    |> memory.insert_row("users", dict.from_list([#("id", ast.IntValue(1))]))
+    |> memory.insert_row("users", dict.from_list([#("id", ast.IntValue(2))]))
+
+  let delete = ast.new_delete("users")
+    |> ast.delete_where(query.eq("id", ast.IntValue(1)))
+
+  let store = case memory.execute_delete(store, delete) {
+    Ok(#(new_store, count)) -> {
+      count |> should.equal(1)
+      new_store
+    }
+    Error(_) -> { should.fail() store }
+  }
+
+  // Verify only one remains
+  case memory.execute_select(store, query.from("users")) {
+    Ok(rows) -> list.length(rows) |> should.equal(1)
+    Error(_) -> should.fail()
+  }
+}
+```
+
+### Transaction Tests
+
+```gleam
+pub fn memory_adapter_transaction_commits_test() {
+  let store = memory.new_store()
+    |> memory.create_table("accounts", ["id", "balance"])
+    |> memory.insert_row("accounts", dict.from_list([
+      #("id", ast.IntValue(1)),
+      #("balance", ast.IntValue(100)),
+    ]))
+
+  // Start transaction
+  let #(store, tx) = memory.begin_transaction(store)
+
+  // Make changes within transaction
+  let update = ast.new_update("accounts")
+    |> ast.set("balance", ast.IntValue(50))
+    |> ast.update_where(query.eq("id", ast.IntValue(1)))
+
+  let #(store, _) = case memory.execute_update_tx(store, tx, update) {
+    Ok(result) -> result
+    Error(_) -> { should.fail() #(store, []) }
+  }
+
+  // Commit
+  let store = memory.commit_transaction(store, tx)
+
+  // Verify change persisted
+  case memory.execute_select(store, query.from("accounts")) {
+    Ok([row]) -> {
+      dict.get(row, "balance") |> should.equal(Ok(ast.IntValue(50)))
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn memory_adapter_transaction_rollback_test() {
+  let store = memory.new_store()
+    |> memory.create_table("accounts", ["id", "balance"])
+    |> memory.insert_row("accounts", dict.from_list([
+      #("id", ast.IntValue(1)),
+      #("balance", ast.IntValue(100)),
+    ]))
+
+  // Start transaction
+  let #(store, tx) = memory.begin_transaction(store)
+
+  // Make changes
+  let update = ast.new_update("accounts")
+    |> ast.set("balance", ast.IntValue(50))
+    |> ast.update_where(query.eq("id", ast.IntValue(1)))
+
+  let #(store, _) = case memory.execute_update_tx(store, tx, update) {
+    Ok(result) -> result
+    Error(_) -> { should.fail() #(store, []) }
+  }
+
+  // Rollback
+  let store = memory.rollback_transaction(store, tx)
+
+  // Verify change was reverted
+  case memory.execute_select(store, query.from("accounts")) {
+    Ok([row]) -> {
+      dict.get(row, "balance") |> should.equal(Ok(ast.IntValue(100)))
+    }
+    _ -> should.fail()
+  }
+}
+```
+
+### Savepoint Tests
+
+```gleam
+pub fn memory_adapter_savepoint_rollback_test() {
+  let store = memory.new_store()
+    |> memory.create_table("items", ["id", "status"])
+    |> memory.insert_row("items", dict.from_list([
+      #("id", ast.IntValue(1)),
+      #("status", ast.StringValue("pending")),
+    ]))
+
+  // Start transaction
+  let #(store, tx) = memory.begin_transaction(store)
+
+  // First update
+  let update1 = ast.new_update("items")
+    |> ast.set("status", ast.StringValue("processing"))
+    |> ast.update_where(query.eq("id", ast.IntValue(1)))
+  let #(store, _) = memory.execute_update_tx(store, tx, update1) |> result.unwrap(#(store, []))
+
+  // Create savepoint
+  let #(store, sp) = memory.create_savepoint(store, tx, "before_complete")
+
+  // Second update
+  let update2 = ast.new_update("items")
+    |> ast.set("status", ast.StringValue("complete"))
+    |> ast.update_where(query.eq("id", ast.IntValue(1)))
+  let #(store, _) = memory.execute_update_tx(store, tx, update2) |> result.unwrap(#(store, []))
+
+  // Rollback to savepoint
+  let store = memory.rollback_to_savepoint(store, tx, sp)
+
+  // Commit transaction
+  let store = memory.commit_transaction(store, tx)
+
+  // Verify: should be "processing" (savepoint state), not "complete"
+  case memory.execute_select(store, query.from("items")) {
+    Ok([row]) -> {
+      dict.get(row, "status") |> should.equal(Ok(ast.StringValue("processing")))
+    }
+    _ -> should.fail()
+  }
+}
+```
+
+## Ring 3: Integration Tests
+
+Test against real databases when needed:
+
+### PostgreSQL Integration Tests
+
+```gleam
+import cquill/adapter/postgres
+
+// Only run when DATABASE_URL is set
+pub fn postgres_integration_test() {
+  case get_test_database_url() {
+    Error(_) -> {
+      io.println("Skipping: DATABASE_URL not set")
+    }
+    Ok(url) -> {
+      use pool <- setup_test_database(url)
+      run_postgres_tests(pool)
+    }
+  }
+}
+
+fn setup_test_database(url: String) -> fn(fn(Pool) -> a) -> a {
+  fn(test_fn) {
+    // Connect
+    let pool = postgres.connect(postgres.parse_url(url))
+      |> result.unwrap_or_panic()
+
+    // Start transaction (will be rolled back)
+    postgres.begin_transaction(pool)
+
+    // Run test
+    let result = test_fn(pool)
+
+    // Rollback to clean up
+    postgres.rollback_transaction(pool)
+
+    result
+  }
+}
+
+fn run_postgres_tests(pool) {
+  // Your actual tests here
+  let insert = ast.new_insert("users")
+    |> ast.insert_columns(["email"])
+    |> ast.insert_values([[ast.StringValue("test@example.com")]])
+    |> ast.returning(["id"])
+
+  case postgres.execute_insert(pool, insert) {
+    Ok(rows) -> {
+      list.length(rows) |> should.equal(1)
+    }
+    Error(e) -> {
+      io.println("Test failed: " <> error.format(e))
+      should.fail()
+    }
+  }
+}
+```
+
+### Test Fixtures
+
+Create reusable test data:
+
+```gleam
+pub fn with_test_users(store, test_fn: fn(MemoryStore) -> a) -> a {
+  let store = store
+    |> memory.create_table("users", ["id", "email", "name", "active"])
+    |> memory.insert_row("users", dict.from_list([
+      #("id", ast.IntValue(1)),
+      #("email", ast.StringValue("alice@example.com")),
+      #("name", ast.StringValue("Alice")),
+      #("active", ast.BoolValue(True)),
+    ]))
+    |> memory.insert_row("users", dict.from_list([
+      #("id", ast.IntValue(2)),
+      #("email", ast.StringValue("bob@example.com")),
+      #("name", ast.StringValue("Bob")),
+      #("active", ast.BoolValue(False)),
+    ]))
+    |> memory.insert_row("users", dict.from_list([
+      #("id", ast.IntValue(3)),
+      #("email", ast.StringValue("carol@example.com")),
+      #("name", ast.StringValue("Carol")),
+      #("active", ast.BoolValue(True)),
+    ]))
+
+  test_fn(store)
+}
+
+// Usage
+pub fn query_active_users_test() {
+  with_test_users(memory.new_store(), fn(store) {
+    let query = query.from("users")
+      |> query.where(query.eq("active", ast.BoolValue(True)))
+
+    case memory.execute_select(store, query) {
+      Ok(rows) -> list.length(rows) |> should.equal(2)
+      Error(_) -> should.fail()
+    }
+  })
+}
+```
+
+## Testing Error Handling
+
+```gleam
+pub fn handles_not_found_error_test() {
+  let store = memory.new_store()
+    |> memory.create_table("users", ["id"])
+
+  let query = query.from("users")
+    |> query.where(query.eq("id", ast.IntValue(999)))
+
+  case memory.execute_one(store, query) {
+    Error(error.NotFound) -> should.be_true(True)  // Expected
+    Ok(_) -> should.fail()
+    Error(_) -> should.fail()
+  }
+}
+
+pub fn handles_constraint_violation_test() {
+  let store = memory.new_store()
+    |> memory.create_table_with_constraints("users", [
+      #("email", field.String |> field.unique()),
+    ])
+    |> memory.insert_row("users", dict.from_list([
+      #("email", ast.StringValue("taken@example.com")),
+    ]))
+
+  // Try to insert duplicate
+  let result = memory.insert_row(store, "users", dict.from_list([
+    #("email", ast.StringValue("taken@example.com")),
+  ]))
+
+  case result {
+    Error(error.UniqueViolation(_, _)) -> should.be_true(True)
+    _ -> should.fail()
+  }
+}
+```
+
+## Running Tests
+
+```bash
+# Run all tests
+gleam test
+
+# Run specific test module
+gleam test test/my_module_test.gleam
+
+# Run with verbose output
+gleam test -- --verbose
+```
+
+## Best Practices
+
+1. **Use memory adapter for unit tests** - Fast and isolated
+2. **Test error paths** - Don't just test happy paths
+3. **Use fixtures for common setup** - Reduce duplication
+4. **Keep integration tests separate** - They're slower
+5. **Clean up after tests** - Use transactions that rollback
+
+## Next Steps
+
+- See [CRUD Operations](./crud.md) for operations to test
+- Read about [Transactions](./transactions.md) for testing atomic operations
+- Check [Error Reference](../reference/errors.md) for error types to test

--- a/docs/guides/transactions.md
+++ b/docs/guides/transactions.md
@@ -1,0 +1,418 @@
+# Transactions
+
+Transactions ensure that multiple database operations either all succeed or all fail together. This guide covers transaction patterns in cquill.
+
+## Basic Transactions
+
+### Simple Transaction
+
+```gleam
+import cquill/repo
+import cquill/query/ast
+
+repo.transaction(adapter, fn(tx) {
+  // Create order
+  let order_insert = ast.new_insert("orders")
+    |> ast.insert_columns(["customer_id", "total"])
+    |> ast.insert_values([[ast.IntValue(1), ast.FloatValue(99.99)]])
+    |> ast.returning(["id"])
+
+  use order_rows <- result.try(repo.insert(tx, order_insert))
+  let order_id = get_id(order_rows)
+
+  // Create order items
+  let items_insert = ast.new_insert("order_items")
+    |> ast.insert_columns(["order_id", "product_id", "quantity"])
+    |> ast.insert_values([[
+      ast.IntValue(order_id),
+      ast.IntValue(42),
+      ast.IntValue(2),
+    ]])
+
+  use _ <- result.try(repo.insert(tx, items_insert))
+
+  // Update inventory
+  let update = ast.new_update("products")
+    |> ast.set("stock", ast.IntValue(98))  // Decrement
+    |> ast.update_where(query.eq("id", ast.IntValue(42)))
+
+  use _ <- result.try(repo.update(tx, update))
+
+  Ok(order_id)
+})
+```
+
+### Transaction Result Handling
+
+```gleam
+case repo.transaction(adapter, my_transaction_fn) {
+  Ok(result) -> {
+    io.println("Transaction succeeded: " <> string.inspect(result))
+  }
+  Error(error.TransactionFailed(reason)) -> {
+    io.println("Transaction failed: " <> reason)
+    // All changes have been rolled back
+  }
+  Error(e) -> {
+    io.println("Error: " <> error.format(e))
+  }
+}
+```
+
+## Savepoints
+
+Savepoints allow partial rollback within a transaction.
+
+### Creating Savepoints
+
+```gleam
+repo.transaction(adapter, fn(tx) {
+  // Create the main order
+  use order <- result.try(create_order(tx))
+
+  // Create a savepoint before processing items
+  use sp <- repo.savepoint(tx, "process_items")
+
+  // Try to process items
+  case process_order_items(tx, order.id) {
+    Ok(items) -> {
+      // Success - release the savepoint
+      repo.release_savepoint(tx, sp)
+      Ok(#(order, items))
+    }
+    Error(_) -> {
+      // Failed - rollback to savepoint
+      repo.rollback_to_savepoint(tx, sp)
+      // Order still exists, but items are rolled back
+      Ok(#(order, []))
+    }
+  }
+})
+```
+
+### Nested Savepoints
+
+```gleam
+repo.transaction(adapter, fn(tx) {
+  use user <- result.try(create_user(tx))
+
+  // First savepoint for profile
+  use sp1 <- repo.savepoint(tx, "create_profile")
+
+  case create_profile(tx, user.id) {
+    Ok(profile) -> {
+      // Nested savepoint for preferences
+      use sp2 <- repo.savepoint(tx, "create_preferences")
+
+      case create_preferences(tx, user.id) {
+        Ok(prefs) -> {
+          repo.release_savepoint(tx, sp2)
+          repo.release_savepoint(tx, sp1)
+          Ok(#(user, Some(profile), Some(prefs)))
+        }
+        Error(_) -> {
+          repo.rollback_to_savepoint(tx, sp2)
+          repo.release_savepoint(tx, sp1)
+          Ok(#(user, Some(profile), None))
+        }
+      }
+    }
+    Error(_) -> {
+      repo.rollback_to_savepoint(tx, sp1)
+      Ok(#(user, None, None))
+    }
+  }
+})
+```
+
+## Transaction Patterns
+
+### All or Nothing
+
+The most common pattern - everything succeeds or nothing does:
+
+```gleam
+pub fn transfer_funds(adapter, from_id: Int, to_id: Int, amount: Float) {
+  repo.transaction(adapter, fn(tx) {
+    // Debit source account
+    use _ <- result.try(debit_account(tx, from_id, amount))
+
+    // Credit destination account
+    use _ <- result.try(credit_account(tx, to_id, amount))
+
+    // Create transfer record
+    use transfer <- result.try(create_transfer_record(tx, from_id, to_id, amount))
+
+    Ok(transfer)
+  })
+}
+
+fn debit_account(tx, account_id: Int, amount: Float) {
+  let update = ast.new_update("accounts")
+    |> ast.set_raw("balance", "balance - $1", [ast.FloatValue(amount)])
+    |> ast.update_where(query.and_where([
+      query.eq("id", ast.IntValue(account_id)),
+      query.gte("balance", ast.FloatValue(amount)),  // Ensure sufficient funds
+    ]))
+    |> ast.returning(["id", "balance"])
+
+  case repo.update(tx, update) {
+    Ok([]) -> Error(error.NotFound)  // No rows updated = insufficient funds
+    Ok(_) -> Ok(Nil)
+    Error(e) -> Error(e)
+  }
+}
+```
+
+### Partial Success with Savepoints
+
+Allow some operations to fail while preserving others:
+
+```gleam
+pub fn import_products(adapter, products: List(ProductData)) {
+  repo.transaction(adapter, fn(tx) {
+    // Import each product, collecting results
+    let results = list.map(products, fn(product) {
+      use sp <- repo.savepoint(tx, "import_" <> product.sku)
+
+      case insert_product(tx, product) {
+        Ok(id) -> {
+          repo.release_savepoint(tx, sp)
+          Ok(#(product.sku, id))
+        }
+        Error(e) -> {
+          repo.rollback_to_savepoint(tx, sp)
+          Error(#(product.sku, e))
+        }
+      }
+    })
+
+    // Separate successes and failures
+    let successes = list.filter_map(results, fn(r) {
+      case r { Ok(x) -> Ok(x) Error(_) -> Error(Nil) }
+    })
+    let failures = list.filter_map(results, fn(r) {
+      case r { Error(x) -> Ok(x) Ok(_) -> Error(Nil) }
+    })
+
+    Ok(#(successes, failures))
+  })
+}
+```
+
+### Optimistic Locking
+
+Detect concurrent modifications:
+
+```gleam
+pub fn update_document(adapter, doc_id: Int, new_content: String, expected_version: Int) {
+  repo.transaction(adapter, fn(tx) {
+    // Update only if version matches
+    let update = ast.new_update("documents")
+      |> ast.set("content", ast.StringValue(new_content))
+      |> ast.set("version", ast.IntValue(expected_version + 1))
+      |> ast.set("updated_at", ast.StringValue(now()))
+      |> ast.update_where(query.and_where([
+        query.eq("id", ast.IntValue(doc_id)),
+        query.eq("version", ast.IntValue(expected_version)),
+      ]))
+      |> ast.returning(["id", "version"])
+
+    case repo.update(tx, update) {
+      Ok([row]) -> Ok(row)
+      Ok([]) -> {
+        // Version mismatch - fetch current to report
+        let current = repo.one(tx, get_document_query(doc_id))
+        case current {
+          Ok(doc) -> {
+            let current_version = dict.get(doc, "version")
+            Error(error.StaleData(
+              int.to_string(expected_version),
+              string.inspect(current_version),
+            ))
+          }
+          Error(error.NotFound) -> Error(error.NotFound)
+          Error(e) -> Error(e)
+        }
+      }
+      Error(e) -> Error(e)
+    }
+  })
+}
+```
+
+### Idempotent Operations
+
+Make operations safe to retry:
+
+```gleam
+pub fn process_payment(adapter, payment_id: String, amount: Float) {
+  repo.transaction(adapter, fn(tx) {
+    // Check if already processed (idempotency key)
+    let existing = repo.one(tx,
+      query.from("processed_payments")
+      |> query.where(query.eq("payment_id", ast.StringValue(payment_id)))
+    )
+
+    case existing {
+      Ok(_) -> {
+        // Already processed - return existing result
+        Ok(#("already_processed", payment_id))
+      }
+      Error(error.NotFound) -> {
+        // Not processed yet - do the work
+        use _ <- result.try(charge_payment(tx, amount))
+        use _ <- result.try(record_payment(tx, payment_id, amount))
+        Ok(#("processed", payment_id))
+      }
+      Error(e) -> Error(e)
+    }
+  })
+}
+```
+
+## Error Handling in Transactions
+
+### Automatic Rollback
+
+Any error returned from the transaction function triggers a rollback:
+
+```gleam
+repo.transaction(adapter, fn(tx) {
+  use user <- result.try(create_user(tx))
+
+  // If this fails, the user creation is also rolled back
+  use profile <- result.try(create_profile(tx, user.id))
+
+  Ok(#(user, profile))
+})
+```
+
+### Manual Rollback
+
+Explicitly rollback based on business logic:
+
+```gleam
+repo.transaction(adapter, fn(tx) {
+  use order <- result.try(create_order(tx))
+
+  // Business validation
+  case validate_order(order) {
+    Ok(_) -> {
+      use _ <- result.try(finalize_order(tx, order.id))
+      Ok(order)
+    }
+    Error(validation_error) -> {
+      // Rollback by returning an error
+      Error(error.AdapterSpecific("validation", validation_error))
+    }
+  }
+})
+```
+
+### Handling Constraint Violations
+
+```gleam
+repo.transaction(adapter, fn(tx) {
+  let insert = create_user_insert(email)
+
+  case repo.insert(tx, insert) {
+    Ok(rows) -> Ok(rows)
+    Error(error.UniqueViolation("users_email_key", _)) -> {
+      // Handle duplicate email specifically
+      Error(error.AdapterSpecific("duplicate_email", email))
+    }
+    Error(e) -> Error(e)
+  }
+})
+```
+
+## Transaction Isolation
+
+### Read Committed (Default)
+
+The default isolation level. Each statement sees committed data:
+
+```gleam
+// This is the default behavior
+repo.transaction(adapter, fn(tx) {
+  // Each query sees the latest committed data
+  use users <- result.try(repo.all(tx, query.from("users")))
+  // Another transaction may have committed between queries
+  use orders <- result.try(repo.all(tx, query.from("orders")))
+  Ok(#(users, orders))
+})
+```
+
+### Serializable (When Needed)
+
+For critical sections that need complete isolation:
+
+```gleam
+// Use when you need strict isolation
+repo.transaction_with(adapter, TransactionOptions(
+  isolation: Serializable,
+), fn(tx) {
+  // Operations here are fully isolated
+  use balance <- result.try(get_account_balance(tx, account_id))
+  use _ <- result.try(debit_account(tx, account_id, amount))
+  Ok(balance - amount)
+})
+```
+
+## Best Practices
+
+### 1. Keep Transactions Short
+
+```gleam
+// Good: Quick transaction
+repo.transaction(adapter, fn(tx) {
+  use order <- result.try(repo.insert(tx, order_insert))
+  use _ <- result.try(repo.insert(tx, items_insert))
+  Ok(order)
+})
+
+// Avoid: Long-running operations in transactions
+repo.transaction(adapter, fn(tx) {
+  use order <- result.try(repo.insert(tx, order_insert))
+  // DON'T: Call external APIs inside transactions
+  let _ = send_email_notification(order)  // This is slow!
+  Ok(order)
+})
+```
+
+### 2. Don't Nest Transactions
+
+```gleam
+// Avoid: Nested transactions (use savepoints instead)
+repo.transaction(adapter, fn(tx) {
+  repo.transaction(tx, fn(inner_tx) {  // This doesn't work as expected
+    // ...
+  })
+})
+
+// Good: Use savepoints for nested rollback
+repo.transaction(adapter, fn(tx) {
+  use sp <- repo.savepoint(tx, "nested")
+  // ...
+})
+```
+
+### 3. Handle All Error Cases
+
+```gleam
+// Good: Handle specific errors
+case repo.transaction(adapter, my_fn) {
+  Ok(result) -> handle_success(result)
+  Error(error.UniqueViolation(_, _)) -> handle_duplicate()
+  Error(error.ForeignKeyViolation(_, _)) -> handle_fk_error()
+  Error(error.Timeout) -> handle_timeout()
+  Error(e) -> handle_unexpected(e)
+}
+```
+
+## Next Steps
+
+- See [Testing](./testing.md) for testing transactions
+- Read about [Savepoints](../concepts/repo.md#savepoints)
+- Check [Error Reference](../reference/errors.md)

--- a/docs/recipes/audit-log.md
+++ b/docs/recipes/audit-log.md
@@ -1,0 +1,518 @@
+# Audit Logging Recipe
+
+Implement audit logging to track all changes to your data.
+
+## Why Audit Logging?
+
+- **Compliance**: Meet regulatory requirements (GDPR, HIPAA, SOX)
+- **Debugging**: Understand how data changed over time
+- **Security**: Detect unauthorized changes
+- **Recovery**: Know what to restore after incidents
+
+## Basic Implementation
+
+### Audit Log Table
+
+```sql
+CREATE TABLE audit_logs (
+  id BIGSERIAL PRIMARY KEY,
+  table_name VARCHAR(255) NOT NULL,
+  record_id INTEGER NOT NULL,
+  action VARCHAR(20) NOT NULL,  -- 'INSERT', 'UPDATE', 'DELETE'
+  old_data JSONB,
+  new_data JSONB,
+  changed_fields TEXT[],
+  user_id INTEGER,
+  user_ip VARCHAR(45),
+  user_agent TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_audit_logs_table_record ON audit_logs(table_name, record_id);
+CREATE INDEX idx_audit_logs_user ON audit_logs(user_id);
+CREATE INDEX idx_audit_logs_created ON audit_logs(created_at);
+```
+
+### Audit Log Types
+
+```gleam
+pub type AuditAction {
+  Insert
+  Update
+  Delete
+}
+
+pub type AuditEntry {
+  AuditEntry(
+    table_name: String,
+    record_id: Int,
+    action: AuditAction,
+    old_data: Option(Dict(String, ast.Value)),
+    new_data: Option(Dict(String, ast.Value)),
+    changed_fields: List(String),
+    user_id: Option(Int),
+    user_ip: Option(String),
+    user_agent: Option(String),
+  )
+}
+
+pub type AuditContext {
+  AuditContext(
+    user_id: Option(Int),
+    user_ip: Option(String),
+    user_agent: Option(String),
+  )
+}
+```
+
+### Core Audit Functions
+
+```gleam
+import cquill/query/ast
+import cquill/repo
+import gleam/json
+
+/// Log an audit entry
+pub fn log_audit(adapter, entry: AuditEntry) -> Result(Nil, error.AdapterError) {
+  let action_str = case entry.action {
+    Insert -> "INSERT"
+    Update -> "UPDATE"
+    Delete -> "DELETE"
+  }
+
+  let insert =
+    ast.new_insert("audit_logs")
+    |> ast.insert_columns([
+      "table_name", "record_id", "action",
+      "old_data", "new_data", "changed_fields",
+      "user_id", "user_ip", "user_agent",
+    ])
+    |> ast.insert_values([[
+      ast.StringValue(entry.table_name),
+      ast.IntValue(entry.record_id),
+      ast.StringValue(action_str),
+      encode_json_value(entry.old_data),
+      encode_json_value(entry.new_data),
+      encode_array(entry.changed_fields),
+      option_to_value(entry.user_id, ast.IntValue),
+      option_to_value(entry.user_ip, ast.StringValue),
+      option_to_value(entry.user_agent, ast.StringValue),
+    ]])
+
+  case repo.insert(adapter, insert) {
+    Ok(_) -> Ok(Nil)
+    Error(e) -> Error(e)
+  }
+}
+
+fn encode_json_value(data: Option(Dict(String, ast.Value))) -> ast.Value {
+  case data {
+    Some(d) -> ast.StringValue(json.to_string(dict_to_json(d)))
+    None -> ast.NullValue
+  }
+}
+
+fn option_to_value(opt: Option(a), f: fn(a) -> ast.Value) -> ast.Value {
+  case opt {
+    Some(v) -> f(v)
+    None -> ast.NullValue
+  }
+}
+```
+
+### Audited Operations
+
+```gleam
+/// Insert with audit logging
+pub fn audited_insert(
+  adapter,
+  table: String,
+  data: Dict(String, ast.Value),
+  context: AuditContext,
+) -> Result(Dict(String, ast.Value), error.AdapterError) {
+  repo.transaction(adapter, fn(tx) {
+    // Perform insert
+    let columns = dict.keys(data)
+    let values = dict.values(data) |> list.map(fn(v) { [v] })
+
+    let insert =
+      ast.new_insert(table)
+      |> ast.insert_columns(columns)
+      |> ast.insert_values(values)
+      |> ast.returning(["id"] |> list.append(columns))
+
+    use rows <- result.try(repo.insert(tx, insert))
+
+    case list.first(rows) {
+      Ok(row) -> {
+        // Get the inserted ID
+        let record_id = case dict.get(row, "id") {
+          Ok(ast.IntValue(id)) -> id
+          _ -> 0
+        }
+
+        // Log the audit entry
+        let entry = AuditEntry(
+          table_name: table,
+          record_id: record_id,
+          action: Insert,
+          old_data: None,
+          new_data: Some(row),
+          changed_fields: columns,
+          user_id: context.user_id,
+          user_ip: context.user_ip,
+          user_agent: context.user_agent,
+        )
+
+        use _ <- result.try(log_audit(tx, entry))
+
+        Ok(row)
+      }
+      Error(_) -> Error(error.NotFound)
+    }
+  })
+}
+
+/// Update with audit logging
+pub fn audited_update(
+  adapter,
+  table: String,
+  id: Int,
+  changes: Dict(String, ast.Value),
+  context: AuditContext,
+) -> Result(Dict(String, ast.Value), error.AdapterError) {
+  repo.transaction(adapter, fn(tx) {
+    // Fetch current record
+    let select_query =
+      query.from(table)
+      |> query.where(query.eq("id", ast.IntValue(id)))
+
+    use old_data <- result.try(repo.one(tx, select_query))
+
+    // Perform update
+    let update = list.fold(dict.to_list(changes), ast.new_update(table), fn(q, pair) {
+      let #(column, value) = pair
+      ast.set(q, column, value)
+    })
+    |> ast.update_where(query.eq("id", ast.IntValue(id)))
+    |> ast.returning(dict.keys(old_data) |> list.append(["id"]))
+
+    use rows <- result.try(repo.update(tx, update))
+
+    case list.first(rows) {
+      Ok(new_data) -> {
+        // Calculate changed fields
+        let changed_fields = dict.keys(changes)
+          |> list.filter(fn(key) {
+            dict.get(old_data, key) != dict.get(new_data, key)
+          })
+
+        // Log the audit entry
+        let entry = AuditEntry(
+          table_name: table,
+          record_id: id,
+          action: Update,
+          old_data: Some(old_data),
+          new_data: Some(new_data),
+          changed_fields: changed_fields,
+          user_id: context.user_id,
+          user_ip: context.user_ip,
+          user_agent: context.user_agent,
+        )
+
+        use _ <- result.try(log_audit(tx, entry))
+
+        Ok(new_data)
+      }
+      Error(_) -> Error(error.NotFound)
+    }
+  })
+}
+
+/// Delete with audit logging
+pub fn audited_delete(
+  adapter,
+  table: String,
+  id: Int,
+  context: AuditContext,
+) -> Result(Nil, error.AdapterError) {
+  repo.transaction(adapter, fn(tx) {
+    // Fetch current record before deletion
+    let select_query =
+      query.from(table)
+      |> query.where(query.eq("id", ast.IntValue(id)))
+
+    use old_data <- result.try(repo.one(tx, select_query))
+
+    // Perform delete
+    let delete =
+      ast.new_delete(table)
+      |> ast.delete_where(query.eq("id", ast.IntValue(id)))
+
+    use count <- result.try(repo.delete(tx, delete))
+
+    case count {
+      0 -> Error(error.NotFound)
+      _ -> {
+        // Log the audit entry
+        let entry = AuditEntry(
+          table_name: table,
+          record_id: id,
+          action: Delete,
+          old_data: Some(old_data),
+          new_data: None,
+          changed_fields: [],
+          user_id: context.user_id,
+          user_ip: context.user_ip,
+          user_agent: context.user_agent,
+        )
+
+        use _ <- result.try(log_audit(tx, entry))
+
+        Ok(Nil)
+      }
+    }
+  })
+}
+```
+
+## Querying Audit Logs
+
+```gleam
+/// Get audit history for a record
+pub fn get_record_history(
+  adapter,
+  table: String,
+  record_id: Int,
+) -> Result(List(Dict(String, ast.Value)), error.AdapterError) {
+  let query =
+    query.from("audit_logs")
+    |> query.where(query.eq("table_name", ast.StringValue(table)))
+    |> query.where(query.eq("record_id", ast.IntValue(record_id)))
+    |> query.order_by_desc("created_at")
+
+  repo.all(adapter, query)
+}
+
+/// Get recent audit logs for a user
+pub fn get_user_activity(
+  adapter,
+  user_id: Int,
+  limit: Int,
+) -> Result(List(Dict(String, ast.Value)), error.AdapterError) {
+  let query =
+    query.from("audit_logs")
+    |> query.where(query.eq("user_id", ast.IntValue(user_id)))
+    |> query.order_by_desc("created_at")
+    |> query.limit(limit)
+
+  repo.all(adapter, query)
+}
+
+/// Get changes to a specific field
+pub fn get_field_changes(
+  adapter,
+  table: String,
+  record_id: Int,
+  field: String,
+) -> Result(List(Dict(String, ast.Value)), error.AdapterError) {
+  let query =
+    query.from("audit_logs")
+    |> query.where(query.eq("table_name", ast.StringValue(table)))
+    |> query.where(query.eq("record_id", ast.IntValue(record_id)))
+    |> query.where(query.raw(
+      "$1 = ANY(changed_fields)",
+      [ast.StringValue(field)],
+    ))
+    |> query.order_by_desc("created_at")
+
+  repo.all(adapter, query)
+}
+```
+
+## Usage Example
+
+```gleam
+// Create audit context from request
+let context = AuditContext(
+  user_id: Some(current_user.id),
+  user_ip: Some(request.client_ip),
+  user_agent: Some(request.headers.user_agent),
+)
+
+// Create user with audit
+let user_data = dict.from_list([
+  #("email", ast.StringValue("alice@example.com")),
+  #("name", ast.StringValue("Alice")),
+])
+
+case audited_insert(adapter, "users", user_data, context) {
+  Ok(user) -> {
+    io.println("Created user: " <> string.inspect(user))
+  }
+  Error(e) -> handle_error(e)
+}
+
+// Update user with audit
+let changes = dict.from_list([
+  #("name", ast.StringValue("Alice Smith")),
+])
+
+case audited_update(adapter, "users", user_id, changes, context) {
+  Ok(user) -> {
+    io.println("Updated user: " <> string.inspect(user))
+  }
+  Error(e) -> handle_error(e)
+}
+
+// View history
+case get_record_history(adapter, "users", user_id) {
+  Ok(history) -> {
+    list.each(history, fn(entry) {
+      io.println("Action: " <> string.inspect(dict.get(entry, "action")))
+      io.println("At: " <> string.inspect(dict.get(entry, "created_at")))
+      io.println("Changed: " <> string.inspect(dict.get(entry, "changed_fields")))
+      io.println("---")
+    })
+  }
+  Error(e) -> handle_error(e)
+}
+```
+
+## Advanced: Automatic Audit with Telemetry
+
+Use telemetry to automatically audit all operations:
+
+```gleam
+import cquill/telemetry
+
+pub fn setup_audit_telemetry(adapter, get_context: fn() -> AuditContext) {
+  // This is conceptual - actual implementation depends on your telemetry setup
+  telemetry.attach(
+    "audit-logger",
+    [
+      telemetry.QueryStopType,
+    ],
+    fn(event, metadata) {
+      case event {
+        telemetry.QueryStop(e) -> {
+          // Parse the query to determine if it's INSERT/UPDATE/DELETE
+          // and log accordingly
+          case parse_mutation_type(e.query) {
+            Some(Insert) -> {
+              // Extract table and data, log audit
+            }
+            Some(Update) -> {
+              // Extract table, id, changes, log audit
+            }
+            Some(Delete) -> {
+              // Extract table and id, log audit
+            }
+            None -> Nil  // SELECT, no audit needed
+          }
+        }
+        _ -> Nil
+      }
+    }
+  )
+}
+```
+
+## Retention and Cleanup
+
+```gleam
+/// Delete audit logs older than specified days
+pub fn cleanup_old_audit_logs(
+  adapter,
+  retention_days: Int,
+) -> Result(Int, error.AdapterError) {
+  let cutoff_date = calculate_cutoff_date(retention_days)
+
+  let delete =
+    ast.new_delete("audit_logs")
+    |> ast.delete_where(query.lt("created_at", ast.StringValue(cutoff_date)))
+
+  repo.delete(adapter, delete)
+}
+
+/// Archive audit logs to separate table
+pub fn archive_audit_logs(
+  adapter,
+  before_date: String,
+) -> Result(Int, error.AdapterError) {
+  repo.transaction(adapter, fn(tx) {
+    // Copy to archive table
+    let copy_result = repo.execute_raw(tx,
+      "INSERT INTO audit_logs_archive SELECT * FROM audit_logs WHERE created_at < $1",
+      [ast.StringValue(before_date)],
+    )
+
+    use _ <- result.try(copy_result)
+
+    // Delete from main table
+    let delete =
+      ast.new_delete("audit_logs")
+      |> ast.delete_where(query.lt("created_at", ast.StringValue(before_date)))
+
+    repo.delete(tx, delete)
+  })
+}
+```
+
+## Testing Audit Logging
+
+```gleam
+pub fn audited_insert_creates_audit_log_test() {
+  let store = setup_test_store()
+  let context = AuditContext(user_id: Some(1), user_ip: None, user_agent: None)
+
+  let data = dict.from_list([
+    #("email", ast.StringValue("test@example.com")),
+  ])
+
+  case audited_insert(store, "users", data, context) {
+    Ok(user) -> {
+      // Check audit log was created
+      let audit_query =
+        query.from("audit_logs")
+        |> query.where(query.eq("table_name", ast.StringValue("users")))
+        |> query.where(query.eq("action", ast.StringValue("INSERT")))
+
+      case repo.all(store, audit_query) {
+        Ok([log]) -> {
+          dict.get(log, "user_id") |> should.equal(Ok(ast.IntValue(1)))
+          dict.get(log, "new_data") |> result.is_ok() |> should.be_true()
+        }
+        _ -> should.fail()
+      }
+    }
+    Error(_) -> should.fail()
+  }
+}
+
+pub fn audited_update_records_changes_test() {
+  let store = setup_store_with_user(1)
+  let context = AuditContext(user_id: Some(1), user_ip: None, user_agent: None)
+
+  let changes = dict.from_list([
+    #("name", ast.StringValue("Updated Name")),
+  ])
+
+  case audited_update(store, "users", 1, changes, context) {
+    Ok(_) -> {
+      let audit_query =
+        query.from("audit_logs")
+        |> query.where(query.eq("action", ast.StringValue("UPDATE")))
+
+      case repo.one(store, audit_query) {
+        Ok(log) -> {
+          dict.get(log, "changed_fields")
+          |> should.equal(Ok(ast.ListValue([ast.StringValue("name")])))
+        }
+        Error(_) -> should.fail()
+      }
+    }
+    Error(_) -> should.fail()
+  }
+}
+```

--- a/docs/recipes/multi-tenant.md
+++ b/docs/recipes/multi-tenant.md
@@ -1,0 +1,683 @@
+# Multi-Tenant Recipe
+
+Patterns for implementing multi-tenant applications with cquill.
+
+## Multi-Tenancy Strategies
+
+### 1. Row-Level (Shared Database, Shared Schema)
+
+All tenants share tables with a `tenant_id` column.
+
+**Pros:**
+- Simplest to implement
+- Efficient resource usage
+- Easy cross-tenant queries (admin)
+
+**Cons:**
+- Risk of data leaks if filters forgotten
+- Harder to customize per tenant
+
+### 2. Schema-Level (Shared Database, Separate Schemas)
+
+Each tenant has their own PostgreSQL schema.
+
+**Pros:**
+- Strong data isolation
+- Easy per-tenant customization
+- Simple backup/restore per tenant
+
+**Cons:**
+- More complex connection management
+- Schema migrations for each tenant
+
+### 3. Database-Level (Separate Databases)
+
+Each tenant has their own database.
+
+**Pros:**
+- Complete isolation
+- Independent scaling
+- Maximum customization
+
+**Cons:**
+- Highest resource overhead
+- Complex management
+
+## Row-Level Multi-Tenancy
+
+### Schema Design
+
+```sql
+-- Add tenant_id to all tenant-scoped tables
+ALTER TABLE users ADD COLUMN tenant_id INTEGER NOT NULL REFERENCES tenants(id);
+ALTER TABLE orders ADD COLUMN tenant_id INTEGER NOT NULL REFERENCES tenants(id);
+ALTER TABLE products ADD COLUMN tenant_id INTEGER NOT NULL REFERENCES tenants(id);
+
+-- Create indexes for tenant queries
+CREATE INDEX idx_users_tenant ON users(tenant_id);
+CREATE INDEX idx_orders_tenant ON orders(tenant_id);
+CREATE INDEX idx_products_tenant ON products(tenant_id);
+
+-- Composite indexes for common queries
+CREATE INDEX idx_orders_tenant_created ON orders(tenant_id, created_at DESC);
+```
+
+### Tenant Context
+
+```gleam
+import cquill/query
+import cquill/query/ast
+
+/// Current tenant context
+pub type TenantContext {
+  TenantContext(
+    tenant_id: Int,
+    tenant_name: String,
+    is_admin: Bool,
+  )
+}
+
+/// Global tenant context - thread-local in real apps
+pub opaque type TenantState {
+  TenantState(context: Option(TenantContext))
+}
+
+/// Set current tenant
+pub fn set_tenant(state: TenantState, context: TenantContext) -> TenantState {
+  TenantState(context: Some(context))
+}
+
+/// Clear tenant context
+pub fn clear_tenant(state: TenantState) -> TenantState {
+  TenantState(context: None)
+}
+
+/// Get current tenant (fails if not set)
+pub fn require_tenant(state: TenantState) -> Result(TenantContext, String) {
+  case state.context {
+    Some(ctx) -> Ok(ctx)
+    None -> Error("No tenant context set")
+  }
+}
+```
+
+### Scoped Queries
+
+```gleam
+/// Automatically scope query to current tenant
+pub fn scoped(
+  base_query: query.Query(a),
+  tenant_id: Int,
+) -> query.Query(a) {
+  base_query
+  |> query.where(query.eq("tenant_id", ast.IntValue(tenant_id)))
+}
+
+/// Create scoped query from table name
+pub fn from_scoped(table: String, tenant_id: Int) -> query.Query(Nil) {
+  query.from(table)
+  |> query.where(query.eq("tenant_id", ast.IntValue(tenant_id)))
+}
+
+/// Usage
+pub fn get_tenant_users(adapter, tenant_id: Int) {
+  from_scoped("users", tenant_id)
+  |> query.order_by_asc("name")
+  |> repo.all(adapter, _)
+}
+```
+
+### Scoped Repository
+
+```gleam
+import cquill/repo
+import cquill/error
+
+/// Tenant-scoped repository wrapper
+pub type TenantRepo {
+  TenantRepo(
+    adapter: adapter.Adapter,
+    tenant_id: Int,
+  )
+}
+
+pub fn new(adapter, tenant_id: Int) -> TenantRepo {
+  TenantRepo(adapter: adapter, tenant_id: tenant_id)
+}
+
+/// Scoped select - automatically filters by tenant
+pub fn all(
+  repo: TenantRepo,
+  base_query: query.Query(a),
+) -> Result(List(Row), error.AdapterError) {
+  let scoped_query = scoped(base_query, repo.tenant_id)
+  repo.all(repo.adapter, scoped_query)
+}
+
+/// Scoped one - automatically filters by tenant
+pub fn one(
+  repo: TenantRepo,
+  base_query: query.Query(a),
+) -> Result(Row, error.AdapterError) {
+  let scoped_query = scoped(base_query, repo.tenant_id)
+  repo.one(repo.adapter, scoped_query)
+}
+
+/// Scoped insert - automatically adds tenant_id
+pub fn insert(
+  trepo: TenantRepo,
+  table: String,
+  data: Dict(String, ast.Value),
+) -> Result(List(Row), error.AdapterError) {
+  // Add tenant_id to the data
+  let data_with_tenant = dict.insert(
+    data,
+    "tenant_id",
+    ast.IntValue(trepo.tenant_id),
+  )
+
+  let columns = dict.keys(data_with_tenant)
+  let values = dict.values(data_with_tenant) |> list.map(fn(v) { [v] })
+
+  let insert =
+    ast.new_insert(table)
+    |> ast.insert_columns(columns)
+    |> ast.insert_values(values)
+    |> ast.returning(["id"] |> list.append(columns))
+
+  repo.insert(trepo.adapter, insert)
+}
+
+/// Scoped update - only updates within tenant
+pub fn update(
+  trepo: TenantRepo,
+  table: String,
+  id: Int,
+  changes: Dict(String, ast.Value),
+) -> Result(List(Row), error.AdapterError) {
+  let update = list.fold(dict.to_list(changes), ast.new_update(table), fn(q, pair) {
+    let #(column, value) = pair
+    ast.set(q, column, value)
+  })
+  |> ast.update_where(query.and_where([
+    query.eq("id", ast.IntValue(id)),
+    query.eq("tenant_id", ast.IntValue(trepo.tenant_id)),
+  ]))
+  |> ast.returning(dict.keys(changes))
+
+  repo.update(trepo.adapter, update)
+}
+
+/// Scoped delete - only deletes within tenant
+pub fn delete(
+  trepo: TenantRepo,
+  table: String,
+  id: Int,
+) -> Result(Int, error.AdapterError) {
+  let delete =
+    ast.new_delete(table)
+    |> ast.delete_where(query.and_where([
+      query.eq("id", ast.IntValue(id)),
+      query.eq("tenant_id", ast.IntValue(trepo.tenant_id)),
+    ]))
+
+  repo.delete(trepo.adapter, delete)
+}
+```
+
+### Usage Example
+
+```gleam
+// Get tenant from authentication
+let tenant_id = get_tenant_from_auth(request)
+
+// Create scoped repository
+let trepo = tenant_repo.new(adapter, tenant_id)
+
+// All queries are automatically scoped
+case tenant_repo.all(trepo, query.from("users")) {
+  Ok(users) -> {
+    // These are only users for this tenant
+    display_users(users)
+  }
+  Error(e) -> handle_error(e)
+}
+
+// Inserts automatically include tenant_id
+let user_data = dict.from_list([
+  #("email", ast.StringValue("alice@example.com")),
+  #("name", ast.StringValue("Alice")),
+])
+
+case tenant_repo.insert(trepo, "users", user_data) {
+  Ok([user]) -> {
+    // User was created with correct tenant_id
+    Ok(user)
+  }
+  Error(e) -> Error(e)
+}
+```
+
+## Schema-Level Multi-Tenancy
+
+### Schema Management
+
+```gleam
+/// Create schema for new tenant
+pub fn create_tenant_schema(
+  adapter,
+  tenant_slug: String,
+) -> Result(Nil, error.AdapterError) {
+  let schema_name = "tenant_" <> tenant_slug
+
+  // Create the schema
+  use _ <- result.try(repo.execute_raw(
+    adapter,
+    "CREATE SCHEMA " <> schema_name,
+    [],
+  ))
+
+  // Run migrations in the new schema
+  use _ <- result.try(run_migrations_in_schema(adapter, schema_name))
+
+  Ok(Nil)
+}
+
+/// Drop tenant schema (careful!)
+pub fn drop_tenant_schema(
+  adapter,
+  tenant_slug: String,
+) -> Result(Nil, error.AdapterError) {
+  let schema_name = "tenant_" <> tenant_slug
+
+  repo.execute_raw(
+    adapter,
+    "DROP SCHEMA " <> schema_name <> " CASCADE",
+    [],
+  )
+  |> result.map(fn(_) { Nil })
+}
+```
+
+### Schema-Scoped Queries
+
+```gleam
+/// Set search_path for tenant
+pub fn with_tenant_schema(
+  adapter,
+  tenant_slug: String,
+  operation: fn() -> Result(a, error.AdapterError),
+) -> Result(a, error.AdapterError) {
+  let schema_name = "tenant_" <> tenant_slug
+
+  // Set schema
+  use _ <- result.try(repo.execute_raw(
+    adapter,
+    "SET search_path TO " <> schema_name <> ", public",
+    [],
+  ))
+
+  // Run operation
+  let result = operation()
+
+  // Reset schema (best effort)
+  let _ = repo.execute_raw(adapter, "SET search_path TO public", [])
+
+  result
+}
+
+/// Usage
+with_tenant_schema(adapter, "acme", fn() {
+  // All queries now target tenant_acme schema
+  query.from("users")
+  |> repo.all(adapter, _)
+})
+```
+
+### Connection Per Tenant
+
+```gleam
+import gleam/dict
+
+/// Pool of connections per tenant
+pub type TenantPools {
+  TenantPools(pools: Dict(String, adapter.Adapter))
+}
+
+/// Get or create connection pool for tenant
+pub fn get_tenant_pool(
+  pools: TenantPools,
+  tenant_slug: String,
+  base_config: postgres.Config,
+) -> Result(#(TenantPools, adapter.Adapter), error.AdapterError) {
+  case dict.get(pools.pools, tenant_slug) {
+    Ok(pool) -> Ok(#(pools, pool))
+    Error(_) -> {
+      // Create new pool with schema set
+      let config = postgres.Config(
+        ...base_config,
+        // Set default schema in connection
+        options: [#("options", "-c search_path=tenant_" <> tenant_slug)],
+      )
+
+      use pool <- result.try(postgres.connect(config))
+
+      let new_pools = TenantPools(
+        pools: dict.insert(pools.pools, tenant_slug, pool),
+      )
+
+      Ok(#(new_pools, pool))
+    }
+  }
+}
+```
+
+## Database-Level Multi-Tenancy
+
+### Tenant Database Management
+
+```gleam
+/// Tenant database configuration
+pub type TenantDatabase {
+  TenantDatabase(
+    tenant_id: Int,
+    tenant_slug: String,
+    database_name: String,
+    host: String,
+    port: Int,
+  )
+}
+
+/// Create database for new tenant
+pub fn provision_tenant_database(
+  admin_adapter,
+  tenant: TenantDatabase,
+) -> Result(Nil, error.AdapterError) {
+  // Create database
+  use _ <- result.try(repo.execute_raw(
+    admin_adapter,
+    "CREATE DATABASE " <> tenant.database_name,
+    [],
+  ))
+
+  // Connect to new database and run migrations
+  let config = postgres.Config(
+    host: tenant.host,
+    port: tenant.port,
+    database: tenant.database_name,
+    user: "app_user",
+    password: get_password(),
+    pool_size: 5,
+    ssl: True,
+    connection_timeout: 5000,
+    query_timeout: 30000,
+  )
+
+  use pool <- result.try(postgres.connect(config))
+  run_migrations(pool)
+}
+```
+
+### Dynamic Connection Routing
+
+```gleam
+import gleam/dict
+
+/// Connection router for multi-database tenancy
+pub type ConnectionRouter {
+  ConnectionRouter(
+    connections: Dict(Int, adapter.Adapter),
+    config_lookup: fn(Int) -> Result(postgres.Config, String),
+  )
+}
+
+pub fn new_router(
+  config_lookup: fn(Int) -> Result(postgres.Config, String),
+) -> ConnectionRouter {
+  ConnectionRouter(
+    connections: dict.new(),
+    config_lookup: config_lookup,
+  )
+}
+
+/// Get connection for tenant
+pub fn get_connection(
+  router: ConnectionRouter,
+  tenant_id: Int,
+) -> Result(#(ConnectionRouter, adapter.Adapter), error.AdapterError) {
+  case dict.get(router.connections, tenant_id) {
+    Ok(conn) -> Ok(#(router, conn))
+    Error(_) -> {
+      // Look up config for tenant
+      case router.config_lookup(tenant_id) {
+        Ok(config) -> {
+          use pool <- result.try(postgres.connect(config))
+
+          let new_router = ConnectionRouter(
+            ...router,
+            connections: dict.insert(router.connections, tenant_id, pool),
+          )
+
+          Ok(#(new_router, pool))
+        }
+        Error(msg) -> Error(error.ConnectionFailed(msg))
+      }
+    }
+  }
+}
+
+/// Execute with tenant connection
+pub fn with_tenant(
+  router: ConnectionRouter,
+  tenant_id: Int,
+  operation: fn(adapter.Adapter) -> Result(a, error.AdapterError),
+) -> Result(#(ConnectionRouter, a), error.AdapterError) {
+  use #(router, conn) <- result.try(get_connection(router, tenant_id))
+  use result <- result.try(operation(conn))
+  Ok(#(router, result))
+}
+```
+
+## Middleware Pattern
+
+For web applications, use middleware to set tenant context:
+
+```gleam
+/// Tenant middleware for web requests
+pub fn tenant_middleware(
+  request: Request,
+  next: fn(Request, TenantContext) -> Response,
+) -> Response {
+  // Extract tenant from subdomain, header, or path
+  case extract_tenant(request) {
+    Ok(tenant_ctx) -> {
+      // Validate tenant exists and is active
+      case validate_tenant(tenant_ctx.tenant_id) {
+        Ok(_) -> next(request, tenant_ctx)
+        Error(_) -> response.not_found("Tenant not found")
+      }
+    }
+    Error(_) -> response.bad_request("Missing tenant identifier")
+  }
+}
+
+fn extract_tenant(request: Request) -> Result(TenantContext, String) {
+  // Option 1: Subdomain (acme.myapp.com)
+  case get_subdomain(request) {
+    Ok(subdomain) -> lookup_tenant_by_subdomain(subdomain)
+    Error(_) -> {
+      // Option 2: Header (X-Tenant-ID)
+      case request.get_header(request, "x-tenant-id") {
+        Ok(tenant_id) -> lookup_tenant_by_id(tenant_id)
+        Error(_) -> {
+          // Option 3: Path prefix (/tenants/:id/...)
+          case extract_tenant_from_path(request.path) {
+            Ok(tenant_id) -> lookup_tenant_by_id(tenant_id)
+            Error(_) -> Error("No tenant identifier found")
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Testing Multi-Tenant Code
+
+```gleam
+pub fn scoped_query_filters_by_tenant_test() {
+  let store = setup_store()
+    |> insert_user(1, "tenant1@example.com", 1)  // tenant 1
+    |> insert_user(2, "tenant2@example.com", 2)  // tenant 2
+    |> insert_user(3, "other@example.com", 1)    // tenant 1
+
+  let trepo = tenant_repo.new(store, 1)
+
+  case tenant_repo.all(trepo, query.from("users")) {
+    Ok(users) -> {
+      // Should only return users from tenant 1
+      list.length(users) |> should.equal(2)
+
+      // Verify all users belong to tenant 1
+      list.all(users, fn(user) {
+        dict.get(user, "tenant_id") == Ok(ast.IntValue(1))
+      })
+      |> should.be_true()
+    }
+    Error(_) -> should.fail()
+  }
+}
+
+pub fn scoped_insert_adds_tenant_id_test() {
+  let store = setup_store()
+  let trepo = tenant_repo.new(store, 42)
+
+  let user_data = dict.from_list([
+    #("email", ast.StringValue("new@example.com")),
+  ])
+
+  case tenant_repo.insert(trepo, "users", user_data) {
+    Ok([user]) -> {
+      // Verify tenant_id was added
+      dict.get(user, "tenant_id")
+      |> should.equal(Ok(ast.IntValue(42)))
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn scoped_update_respects_tenant_boundary_test() {
+  let store = setup_store()
+    |> insert_user(1, "user@example.com", 1)  // tenant 1
+    |> insert_user(2, "other@example.com", 2) // tenant 2
+
+  // Try to update user from tenant 2 while scoped to tenant 1
+  let trepo = tenant_repo.new(store, 1)
+
+  let changes = dict.from_list([
+    #("email", ast.StringValue("hacked@example.com")),
+  ])
+
+  case tenant_repo.update(trepo, "users", 2, changes) {
+    Ok([]) -> {
+      // Update should affect 0 rows (user 2 is in tenant 2)
+      Nil
+    }
+    Ok(_) -> should.fail()  // Should not update
+    Error(_) -> should.fail()
+  }
+
+  // Verify user 2 wasn't modified
+  let query = query.from("users")
+    |> query.where(query.eq("id", ast.IntValue(2)))
+
+  case repo.one(store, query) {
+    Ok(user) -> {
+      dict.get(user, "email")
+      |> should.equal(Ok(ast.StringValue("other@example.com")))
+    }
+    Error(_) -> should.fail()
+  }
+}
+
+pub fn scoped_delete_respects_tenant_boundary_test() {
+  let store = setup_store()
+    |> insert_user(1, "user@example.com", 1)
+    |> insert_user(2, "other@example.com", 2)
+
+  let trepo = tenant_repo.new(store, 1)
+
+  // Try to delete user from tenant 2
+  case tenant_repo.delete(trepo, "users", 2) {
+    Ok(0) -> {
+      // Should delete 0 rows
+      Nil
+    }
+    _ -> should.fail()
+  }
+
+  // Verify user 2 still exists
+  let count_query = query.from("users")
+  case repo.all(store, count_query) {
+    Ok(users) -> list.length(users) |> should.equal(2)
+    Error(_) -> should.fail()
+  }
+}
+```
+
+## Security Considerations
+
+### 1. Always Validate Tenant Access
+
+```gleam
+pub fn require_tenant_access(
+  user: User,
+  tenant_id: Int,
+) -> Result(Nil, String) {
+  case user.tenant_id == tenant_id || user.is_super_admin {
+    True -> Ok(Nil)
+    False -> Error("Access denied to tenant")
+  }
+}
+```
+
+### 2. Audit Cross-Tenant Operations
+
+```gleam
+pub fn audit_cross_tenant_access(
+  user: User,
+  target_tenant_id: Int,
+  operation: String,
+) {
+  case user.tenant_id != target_tenant_id {
+    True -> {
+      log_security_event(
+        "cross_tenant_access",
+        [
+          #("user_id", int.to_string(user.id)),
+          #("user_tenant", int.to_string(user.tenant_id)),
+          #("target_tenant", int.to_string(target_tenant_id)),
+          #("operation", operation),
+        ],
+      )
+    }
+    False -> Nil
+  }
+}
+```
+
+### 3. Prevent Tenant ID Manipulation
+
+```gleam
+/// Never trust tenant_id from user input for ownership
+pub fn update_user_safe(
+  trepo: TenantRepo,
+  user_id: Int,
+  changes: Dict(String, ast.Value),
+) -> Result(List(Row), error.AdapterError) {
+  // Remove tenant_id if present in changes (prevent tenant hopping)
+  let safe_changes = dict.delete(changes, "tenant_id")
+
+  tenant_repo.update(trepo, "users", user_id, safe_changes)
+}
+```

--- a/docs/recipes/pagination.md
+++ b/docs/recipes/pagination.md
@@ -1,0 +1,444 @@
+# Pagination Recipes
+
+Patterns for implementing pagination in cquill applications.
+
+## Offset-Based Pagination
+
+The simplest pagination approach, using LIMIT and OFFSET.
+
+### Basic Implementation
+
+```gleam
+import cquill/query
+import cquill/query/ast
+import cquill/repo
+
+pub type Page(a) {
+  Page(
+    items: List(a),
+    page: Int,
+    per_page: Int,
+    total_count: Int,
+    total_pages: Int,
+  )
+}
+
+pub fn paginate(
+  adapter,
+  base_query: query.Query(a),
+  page: Int,
+  per_page: Int,
+) -> Result(Page(Row), error.AdapterError) {
+  let page = int.max(1, page)
+  let per_page = int.clamp(per_page, 1, 100)
+  let offset = (page - 1) * per_page
+
+  // Get total count
+  use total_count <- result.try(get_count(adapter, base_query))
+
+  // Get page items
+  let paginated_query =
+    base_query
+    |> query.limit(per_page)
+    |> query.offset(offset)
+
+  use items <- result.try(repo.all(adapter, paginated_query))
+
+  let total_pages = { total_count + per_page - 1 } / per_page
+
+  Ok(Page(
+    items: items,
+    page: page,
+    per_page: per_page,
+    total_count: total_count,
+    total_pages: total_pages,
+  ))
+}
+
+fn get_count(adapter, base_query) -> Result(Int, error.AdapterError) {
+  let count_query =
+    query.from(get_table_name(base_query))
+    |> copy_where_conditions(base_query)
+    |> query.select_expr([ast.AggregateExpr(ast.Count, "*")])
+
+  use rows <- result.try(repo.all(adapter, count_query))
+
+  case rows {
+    [row] -> {
+      case dict.get(row, "count") {
+        Ok(ast.IntValue(n)) -> Ok(n)
+        _ -> Ok(0)
+      }
+    }
+    _ -> Ok(0)
+  }
+}
+```
+
+### Usage
+
+```gleam
+// Get page 2 with 20 items per page
+let users_query =
+  query.from("users")
+  |> query.where(query.eq("active", ast.BoolValue(True)))
+  |> query.order_by_asc("name")
+
+case paginate(adapter, users_query, 2, 20) {
+  Ok(page) -> {
+    io.println("Page " <> int.to_string(page.page) <> " of " <> int.to_string(page.total_pages))
+    io.println("Showing " <> int.to_string(list.length(page.items)) <> " of " <> int.to_string(page.total_count))
+    list.each(page.items, display_user)
+  }
+  Error(e) -> handle_error(e)
+}
+```
+
+### Pros and Cons
+
+**Pros:**
+- Simple to implement
+- Can jump to any page
+- Easy to understand
+
+**Cons:**
+- Performance degrades with large offsets
+- Inconsistent results if data changes between pages
+- Not suitable for real-time data
+
+## Cursor-Based Pagination
+
+Better performance for large datasets, using a cursor (typically the last ID or timestamp).
+
+### Basic Implementation
+
+```gleam
+pub type CursorPage(a, cursor) {
+  CursorPage(
+    items: List(a),
+    next_cursor: Option(cursor),
+    has_more: Bool,
+  )
+}
+
+pub fn paginate_by_cursor(
+  adapter,
+  base_query: query.Query(a),
+  cursor: Option(Int),  // Previous page's last ID
+  limit: Int,
+) -> Result(CursorPage(Row, Int), error.AdapterError) {
+  let limit = int.clamp(limit, 1, 100)
+
+  // Build query with cursor condition
+  let query = case cursor {
+    Some(last_id) ->
+      base_query
+      |> query.where(query.gt("id", ast.IntValue(last_id)))
+    None -> base_query
+  }
+
+  // Fetch limit + 1 to check if there are more
+  let query =
+    query
+    |> query.order_by_asc("id")
+    |> query.limit(limit + 1)
+
+  use rows <- result.try(repo.all(adapter, query))
+
+  let has_more = list.length(rows) > limit
+  let items = list.take(rows, limit)
+
+  let next_cursor = case list.last(items) {
+    Ok(last_item) -> {
+      case dict.get(last_item, "id") {
+        Ok(ast.IntValue(id)) -> Some(id)
+        _ -> None
+      }
+    }
+    Error(_) -> None
+  }
+
+  Ok(CursorPage(
+    items: items,
+    next_cursor: next_cursor,
+    has_more: has_more,
+  ))
+}
+```
+
+### Usage
+
+```gleam
+// First page
+case paginate_by_cursor(adapter, users_query, None, 20) {
+  Ok(page) -> {
+    display_items(page.items)
+
+    case page.has_more, page.next_cursor {
+      True, Some(cursor) -> {
+        // Fetch next page
+        paginate_by_cursor(adapter, users_query, Some(cursor), 20)
+      }
+      _, _ -> Ok(page)
+    }
+  }
+  Error(e) -> Error(e)
+}
+```
+
+### Timestamp-Based Cursor
+
+For time-ordered data:
+
+```gleam
+pub fn paginate_by_timestamp(
+  adapter,
+  base_query: query.Query(a),
+  cursor: Option(String),  // ISO timestamp
+  limit: Int,
+) -> Result(CursorPage(Row, String), error.AdapterError) {
+  let query = case cursor {
+    Some(timestamp) ->
+      base_query
+      |> query.where(query.lt("created_at", ast.StringValue(timestamp)))
+    None -> base_query
+  }
+
+  let query =
+    query
+    |> query.order_by_desc("created_at")
+    |> query.limit(limit + 1)
+
+  use rows <- result.try(repo.all(adapter, query))
+
+  let has_more = list.length(rows) > limit
+  let items = list.take(rows, limit)
+
+  let next_cursor = case list.last(items) {
+    Ok(last_item) -> {
+      case dict.get(last_item, "created_at") {
+        Ok(ast.StringValue(ts)) -> Some(ts)
+        _ -> None
+      }
+    }
+    Error(_) -> None
+  }
+
+  Ok(CursorPage(items: items, next_cursor: next_cursor, has_more: has_more))
+}
+```
+
+### Pros and Cons
+
+**Pros:**
+- Consistent performance regardless of page depth
+- Stable results even with data changes
+- Better for infinite scroll UIs
+
+**Cons:**
+- Can't jump to arbitrary pages
+- More complex to implement
+- Requires stable, unique, ordered column
+
+## Keyset Pagination
+
+A variant of cursor pagination using composite keys.
+
+### Implementation
+
+```gleam
+pub type KeysetCursor {
+  KeysetCursor(created_at: String, id: Int)
+}
+
+pub fn paginate_by_keyset(
+  adapter,
+  base_query: query.Query(a),
+  cursor: Option(KeysetCursor),
+  limit: Int,
+) -> Result(CursorPage(Row, KeysetCursor), error.AdapterError) {
+  let query = case cursor {
+    Some(KeysetCursor(created_at, id)) ->
+      base_query
+      |> query.where(query.or_where([
+        // Either older timestamp
+        query.lt("created_at", ast.StringValue(created_at)),
+        // Or same timestamp but lower ID (tie-breaker)
+        query.and_where([
+          query.eq("created_at", ast.StringValue(created_at)),
+          query.lt("id", ast.IntValue(id)),
+        ]),
+      ]))
+    None -> base_query
+  }
+
+  let query =
+    query
+    |> query.order_by_desc("created_at")
+    |> query.order_by_desc("id")
+    |> query.limit(limit + 1)
+
+  use rows <- result.try(repo.all(adapter, query))
+
+  let has_more = list.length(rows) > limit
+  let items = list.take(rows, limit)
+
+  let next_cursor = case list.last(items) {
+    Ok(last_item) -> {
+      case dict.get(last_item, "created_at"), dict.get(last_item, "id") {
+        Ok(ast.StringValue(ts)), Ok(ast.IntValue(id)) ->
+          Some(KeysetCursor(ts, id))
+        _, _ -> None
+      }
+    }
+    Error(_) -> None
+  }
+
+  Ok(CursorPage(items: items, next_cursor: next_cursor, has_more: has_more))
+}
+```
+
+## Seek Pagination
+
+Optimized for large datasets with filtering.
+
+```gleam
+pub fn seek_paginate(
+  adapter,
+  table: String,
+  filters: List(#(String, ast.Value)),
+  order_by: String,
+  seek_value: Option(ast.Value),
+  limit: Int,
+) -> Result(List(Row), error.AdapterError) {
+  let base = query.from(table)
+
+  // Apply filters
+  let query = list.fold(filters, base, fn(q, filter) {
+    let #(field, value) = filter
+    q |> query.where(query.eq(field, value))
+  })
+
+  // Apply seek condition
+  let query = case seek_value {
+    Some(value) -> query |> query.where(query.gt(order_by, value))
+    None -> query
+  }
+
+  query
+  |> query.order_by_asc(order_by)
+  |> query.limit(limit)
+  |> repo.all(adapter, _)
+}
+```
+
+## Pagination Helpers
+
+### Page Info
+
+```gleam
+pub type PageInfo {
+  PageInfo(
+    current_page: Int,
+    per_page: Int,
+    total_count: Int,
+    total_pages: Int,
+    has_previous: Bool,
+    has_next: Bool,
+    start_index: Int,
+    end_index: Int,
+  )
+}
+
+pub fn page_info(page: Int, per_page: Int, total_count: Int) -> PageInfo {
+  let total_pages = case total_count {
+    0 -> 1
+    n -> { n + per_page - 1 } / per_page
+  }
+
+  let start_index = { page - 1 } * per_page + 1
+  let end_index = int.min(page * per_page, total_count)
+
+  PageInfo(
+    current_page: page,
+    per_page: per_page,
+    total_count: total_count,
+    total_pages: total_pages,
+    has_previous: page > 1,
+    has_next: page < total_pages,
+    start_index: start_index,
+    end_index: end_index,
+  )
+}
+```
+
+### Encode/Decode Cursor
+
+For API responses:
+
+```gleam
+import gleam/bit_array
+import gleam/base64
+
+pub fn encode_cursor(cursor: KeysetCursor) -> String {
+  let data = cursor.created_at <> "|" <> int.to_string(cursor.id)
+  base64.encode(bit_array.from_string(data))
+}
+
+pub fn decode_cursor(encoded: String) -> Result(KeysetCursor, Nil) {
+  use decoded <- result.try(base64.decode(encoded))
+  use string <- result.try(bit_array.to_string(decoded))
+
+  case string.split(string, "|") {
+    [created_at, id_str] -> {
+      use id <- result.try(int.parse(id_str))
+      Ok(KeysetCursor(created_at, id))
+    }
+    _ -> Error(Nil)
+  }
+}
+```
+
+## Testing Pagination
+
+```gleam
+pub fn pagination_returns_correct_page_test() {
+  let store = setup_test_store_with_100_users()
+
+  let query = query.from("users") |> query.order_by_asc("id")
+
+  case paginate(store, query, 3, 10) {
+    Ok(page) -> {
+      page.page |> should.equal(3)
+      page.per_page |> should.equal(10)
+      page.total_count |> should.equal(100)
+      page.total_pages |> should.equal(10)
+      list.length(page.items) |> should.equal(10)
+
+      // First item on page 3 should have id 21
+      case list.first(page.items) {
+        Ok(item) -> {
+          dict.get(item, "id") |> should.equal(Ok(ast.IntValue(21)))
+        }
+        Error(_) -> should.fail()
+      }
+    }
+    Error(_) -> should.fail()
+  }
+}
+
+pub fn cursor_pagination_handles_empty_result_test() {
+  let store = setup_empty_test_store()
+
+  let query = query.from("users")
+
+  case paginate_by_cursor(store, query, None, 10) {
+    Ok(page) -> {
+      page.items |> should.equal([])
+      page.has_more |> should.be_false()
+      page.next_cursor |> should.be_none()
+    }
+    Error(_) -> should.fail()
+  }
+}
+```

--- a/docs/recipes/soft-delete.md
+++ b/docs/recipes/soft-delete.md
@@ -1,0 +1,414 @@
+# Soft Delete Recipe
+
+Implement soft delete pattern where records are marked as deleted instead of being removed from the database.
+
+## Why Soft Delete?
+
+- **Audit trail**: Keep history of deleted records
+- **Recovery**: Easily restore accidentally deleted data
+- **Data integrity**: Maintain referential integrity
+- **Compliance**: Meet data retention requirements
+
+## Basic Implementation
+
+### Schema
+
+Add a `deleted_at` column to track deletion time:
+
+```sql
+-- Migration
+ALTER TABLE users ADD COLUMN deleted_at TIMESTAMP;
+CREATE INDEX idx_users_deleted_at ON users(deleted_at);
+```
+
+### Query Helpers
+
+```gleam
+import cquill/query
+import cquill/query/ast
+
+/// Base query that excludes soft-deleted records
+pub fn active(base_query: query.Query(a)) -> query.Query(a) {
+  base_query
+  |> query.where(query.is_null("deleted_at"))
+}
+
+/// Query that only includes soft-deleted records
+pub fn deleted(base_query: query.Query(a)) -> query.Query(a) {
+  base_query
+  |> query.where(query.is_not_null("deleted_at"))
+}
+
+/// Query that includes all records (active and deleted)
+pub fn with_deleted(base_query: query.Query(a)) -> query.Query(a) {
+  // Just return the base query unchanged
+  base_query
+}
+```
+
+### Soft Delete Operation
+
+```gleam
+import cquill/repo
+
+/// Soft delete a record by ID
+pub fn soft_delete(adapter, table: String, id: Int) -> Result(Int, error.AdapterError) {
+  let now = get_current_timestamp()
+
+  let update =
+    ast.new_update(table)
+    |> ast.set("deleted_at", ast.StringValue(now))
+    |> ast.update_where(query.and_where([
+      query.eq("id", ast.IntValue(id)),
+      query.is_null("deleted_at"),  // Don't re-delete
+    ]))
+
+  case repo.update(adapter, update) {
+    Ok(rows) -> Ok(list.length(rows))
+    Error(e) -> Error(e)
+  }
+}
+
+/// Soft delete records matching a condition
+pub fn soft_delete_where(
+  adapter,
+  table: String,
+  condition: query.Condition,
+) -> Result(Int, error.AdapterError) {
+  let now = get_current_timestamp()
+
+  let update =
+    ast.new_update(table)
+    |> ast.set("deleted_at", ast.StringValue(now))
+    |> ast.update_where(query.and_where([
+      condition,
+      query.is_null("deleted_at"),
+    ]))
+
+  case repo.update(adapter, update) {
+    Ok(rows) -> Ok(list.length(rows))
+    Error(e) -> Error(e)
+  }
+}
+```
+
+### Restore Operation
+
+```gleam
+/// Restore a soft-deleted record
+pub fn restore(adapter, table: String, id: Int) -> Result(Int, error.AdapterError) {
+  let update =
+    ast.new_update(table)
+    |> ast.set("deleted_at", ast.NullValue)
+    |> ast.update_where(query.and_where([
+      query.eq("id", ast.IntValue(id)),
+      query.is_not_null("deleted_at"),  // Only restore deleted
+    ]))
+
+  case repo.update(adapter, update) {
+    Ok(rows) -> Ok(list.length(rows))
+    Error(e) -> Error(e)
+  }
+}
+
+/// Restore all soft-deleted records matching condition
+pub fn restore_where(
+  adapter,
+  table: String,
+  condition: query.Condition,
+) -> Result(Int, error.AdapterError) {
+  let update =
+    ast.new_update(table)
+    |> ast.set("deleted_at", ast.NullValue)
+    |> ast.update_where(query.and_where([
+      condition,
+      query.is_not_null("deleted_at"),
+    ]))
+
+  case repo.update(adapter, update) {
+    Ok(rows) -> Ok(list.length(rows))
+    Error(e) -> Error(e)
+  }
+}
+```
+
+### Permanent Delete
+
+```gleam
+/// Permanently delete a soft-deleted record
+pub fn hard_delete(adapter, table: String, id: Int) -> Result(Int, error.AdapterError) {
+  let delete =
+    ast.new_delete(table)
+    |> ast.delete_where(query.and_where([
+      query.eq("id", ast.IntValue(id)),
+      query.is_not_null("deleted_at"),  // Only hard-delete already soft-deleted
+    ]))
+
+  repo.delete(adapter, delete)
+}
+
+/// Purge all soft-deleted records older than a date
+pub fn purge_deleted_before(
+  adapter,
+  table: String,
+  before_date: String,
+) -> Result(Int, error.AdapterError) {
+  let delete =
+    ast.new_delete(table)
+    |> ast.delete_where(query.and_where([
+      query.is_not_null("deleted_at"),
+      query.lt("deleted_at", ast.StringValue(before_date)),
+    ]))
+
+  repo.delete(adapter, delete)
+}
+```
+
+## Usage Example
+
+```gleam
+// Create query for users
+let users = query.from("users")
+
+// Get all active users (excludes deleted)
+let active_users = users |> active()
+case repo.all(adapter, active_users) {
+  Ok(rows) -> display_users(rows)
+  Error(e) -> handle_error(e)
+}
+
+// Get deleted users for admin view
+let deleted_users = users |> deleted()
+case repo.all(adapter, deleted_users) {
+  Ok(rows) -> display_deleted_users(rows)
+  Error(e) -> handle_error(e)
+}
+
+// Soft delete a user
+case soft_delete(adapter, "users", user_id) {
+  Ok(1) -> io.println("User deleted")
+  Ok(0) -> io.println("User not found or already deleted")
+  Ok(_) -> io.println("Unexpected result")
+  Error(e) -> handle_error(e)
+}
+
+// Restore a user
+case restore(adapter, "users", user_id) {
+  Ok(1) -> io.println("User restored")
+  Ok(0) -> io.println("User not found or not deleted")
+  Ok(_) -> io.println("Unexpected result")
+  Error(e) -> handle_error(e)
+}
+```
+
+## Advanced: Soft Delete Module
+
+Create a reusable module:
+
+```gleam
+// soft_delete.gleam
+
+import cquill/query
+import cquill/query/ast
+import cquill/repo
+import cquill/error
+
+pub type SoftDeletable {
+  SoftDeletable(
+    table: String,
+    deleted_at_column: String,
+  )
+}
+
+pub fn new(table: String) -> SoftDeletable {
+  SoftDeletable(table: table, deleted_at_column: "deleted_at")
+}
+
+pub fn with_column(sd: SoftDeletable, column: String) -> SoftDeletable {
+  SoftDeletable(..sd, deleted_at_column: column)
+}
+
+pub fn active_query(sd: SoftDeletable) -> query.Query(Nil) {
+  query.from(sd.table)
+  |> query.where(query.is_null(sd.deleted_at_column))
+}
+
+pub fn deleted_query(sd: SoftDeletable) -> query.Query(Nil) {
+  query.from(sd.table)
+  |> query.where(query.is_not_null(sd.deleted_at_column))
+}
+
+pub fn all_query(sd: SoftDeletable) -> query.Query(Nil) {
+  query.from(sd.table)
+}
+
+pub fn delete(
+  adapter,
+  sd: SoftDeletable,
+  id: Int,
+) -> Result(Bool, error.AdapterError) {
+  let now = get_current_timestamp()
+
+  let update =
+    ast.new_update(sd.table)
+    |> ast.set(sd.deleted_at_column, ast.StringValue(now))
+    |> ast.update_where(query.and_where([
+      query.eq("id", ast.IntValue(id)),
+      query.is_null(sd.deleted_at_column),
+    ]))
+
+  case repo.update(adapter, update) {
+    Ok(rows) -> Ok(list.length(rows) > 0)
+    Error(e) -> Error(e)
+  }
+}
+
+pub fn restore(
+  adapter,
+  sd: SoftDeletable,
+  id: Int,
+) -> Result(Bool, error.AdapterError) {
+  let update =
+    ast.new_update(sd.table)
+    |> ast.set(sd.deleted_at_column, ast.NullValue)
+    |> ast.update_where(query.and_where([
+      query.eq("id", ast.IntValue(id)),
+      query.is_not_null(sd.deleted_at_column),
+    ]))
+
+  case repo.update(adapter, update) {
+    Ok(rows) -> Ok(list.length(rows) > 0)
+    Error(e) -> Error(e)
+  }
+}
+```
+
+### Usage
+
+```gleam
+let users = soft_delete.new("users")
+
+// Query active users
+let active_users = soft_delete.active_query(users)
+  |> query.order_by_asc("name")
+repo.all(adapter, active_users)
+
+// Soft delete
+soft_delete.delete(adapter, users, 123)
+
+// Restore
+soft_delete.restore(adapter, users, 123)
+```
+
+## Cascading Soft Delete
+
+Handle related records when soft deleting:
+
+```gleam
+pub fn soft_delete_user_with_posts(adapter, user_id: Int) {
+  repo.transaction(adapter, fn(tx) {
+    let now = get_current_timestamp()
+
+    // Soft delete user
+    let user_update =
+      ast.new_update("users")
+      |> ast.set("deleted_at", ast.StringValue(now))
+      |> ast.update_where(query.eq("id", ast.IntValue(user_id)))
+
+    use _ <- result.try(repo.update(tx, user_update))
+
+    // Soft delete user's posts
+    let posts_update =
+      ast.new_update("posts")
+      |> ast.set("deleted_at", ast.StringValue(now))
+      |> ast.update_where(query.and_where([
+        query.eq("user_id", ast.IntValue(user_id)),
+        query.is_null("deleted_at"),
+      ]))
+
+    use _ <- result.try(repo.update(tx, posts_update))
+
+    // Soft delete comments on those posts
+    let comments_update =
+      ast.new_update("comments")
+      |> ast.set("deleted_at", ast.StringValue(now))
+      |> ast.update_where(query.raw(
+        "post_id IN (SELECT id FROM posts WHERE user_id = $1)",
+        [ast.IntValue(user_id)],
+      ))
+
+    use _ <- result.try(repo.update(tx, comments_update))
+
+    Ok(Nil)
+  })
+}
+```
+
+## Testing Soft Delete
+
+```gleam
+pub fn soft_delete_marks_record_test() {
+  let store = setup_store_with_user(1, "alice@example.com")
+
+  // Soft delete
+  case soft_delete(store, "users", 1) {
+    Ok(1) -> {
+      // Verify deleted_at is set
+      let query = query.from("users")
+        |> query.where(query.eq("id", ast.IntValue(1)))
+
+      case repo.one(store, query) {
+        Ok(row) -> {
+          dict.get(row, "deleted_at")
+          |> result.is_ok()
+          |> should.be_true()
+        }
+        Error(_) -> should.fail()
+      }
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn active_query_excludes_deleted_test() {
+  let store = setup_store()
+    |> insert_user(1, "active@example.com", None)
+    |> insert_user(2, "deleted@example.com", Some("2024-01-01"))
+
+  let query = query.from("users") |> active()
+
+  case repo.all(store, query) {
+    Ok(rows) -> {
+      list.length(rows) |> should.equal(1)
+      case list.first(rows) {
+        Ok(row) -> {
+          dict.get(row, "id") |> should.equal(Ok(ast.IntValue(1)))
+        }
+        Error(_) -> should.fail()
+      }
+    }
+    Error(_) -> should.fail()
+  }
+}
+
+pub fn restore_clears_deleted_at_test() {
+  let store = setup_store()
+    |> insert_user(1, "test@example.com", Some("2024-01-01"))
+
+  case restore(store, "users", 1) {
+    Ok(1) -> {
+      let query = query.from("users")
+        |> query.where(query.eq("id", ast.IntValue(1)))
+
+      case repo.one(store, query) {
+        Ok(row) -> {
+          dict.get(row, "deleted_at")
+          |> should.equal(Ok(ast.NullValue))
+        }
+        Error(_) -> should.fail()
+      }
+    }
+    _ -> should.fail()
+  }
+}
+```

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,0 +1,603 @@
+# API Reference
+
+Complete reference for all public cquill modules and functions.
+
+## cquill/query
+
+Query builder module for constructing SELECT queries.
+
+### `from(table: String) -> Query(Nil)`
+
+Create a new query for a table.
+
+```gleam
+let q = query.from("users")
+```
+
+### `from_qualified(schema: String, table: String) -> Query(Nil)`
+
+Create a query with schema qualification.
+
+```gleam
+let q = query.from_qualified("public", "users")
+```
+
+### `select(q: Query(a), fields: List(String)) -> Query(a)`
+
+Select specific columns.
+
+```gleam
+query.from("users")
+|> query.select(["id", "email", "name"])
+```
+
+### `select_all(q: Query(a)) -> Query(a)`
+
+Select all columns (SELECT *).
+
+```gleam
+query.from("users")
+|> query.select_all()
+```
+
+### `where(q: Query(a), condition: Condition) -> Query(a)`
+
+Add a WHERE condition. Multiple calls are AND'd together.
+
+```gleam
+query.from("users")
+|> query.where(query.eq("active", ast.BoolValue(True)))
+|> query.where(query.gt("age", ast.IntValue(18)))
+```
+
+### `order_by_asc(q: Query(a), field: String) -> Query(a)`
+
+Add ascending ORDER BY.
+
+```gleam
+query.from("users")
+|> query.order_by_asc("created_at")
+```
+
+### `order_by_desc(q: Query(a), field: String) -> Query(a)`
+
+Add descending ORDER BY.
+
+```gleam
+query.from("users")
+|> query.order_by_desc("score")
+```
+
+### `limit(q: Query(a), n: Int) -> Query(a)`
+
+Limit result count.
+
+```gleam
+query.from("users")
+|> query.limit(10)
+```
+
+### `offset(q: Query(a), n: Int) -> Query(a)`
+
+Skip first n rows.
+
+```gleam
+query.from("users")
+|> query.limit(10)
+|> query.offset(20)
+```
+
+### `distinct(q: Query(a)) -> Query(a)`
+
+Select only distinct rows.
+
+```gleam
+query.from("orders")
+|> query.select(["customer_id"])
+|> query.distinct()
+```
+
+### `group_by(q: Query(a), fields: List(String)) -> Query(a)`
+
+Group results by fields.
+
+```gleam
+query.from("orders")
+|> query.group_by(["customer_id"])
+```
+
+### `having(q: Query(a), condition: Condition) -> Query(a)`
+
+Filter grouped results.
+
+```gleam
+query.from("orders")
+|> query.group_by(["customer_id"])
+|> query.having(query.gt("count", ast.IntValue(5)))
+```
+
+## Condition Functions
+
+### `eq(field: String, value: Value) -> Condition`
+
+Equality condition (field = value).
+
+```gleam
+query.eq("id", ast.IntValue(1))
+```
+
+### `not_eq(field: String, value: Value) -> Condition`
+
+Inequality condition (field != value).
+
+```gleam
+query.not_eq("status", ast.StringValue("deleted"))
+```
+
+### `gt(field: String, value: Value) -> Condition`
+
+Greater than (field > value).
+
+```gleam
+query.gt("age", ast.IntValue(18))
+```
+
+### `gte(field: String, value: Value) -> Condition`
+
+Greater than or equal (field >= value).
+
+```gleam
+query.gte("score", ast.IntValue(100))
+```
+
+### `lt(field: String, value: Value) -> Condition`
+
+Less than (field < value).
+
+```gleam
+query.lt("price", ast.FloatValue(50.0))
+```
+
+### `lte(field: String, value: Value) -> Condition`
+
+Less than or equal (field <= value).
+
+```gleam
+query.lte("quantity", ast.IntValue(10))
+```
+
+### `like(field: String, pattern: String) -> Condition`
+
+Pattern match (field LIKE pattern).
+
+```gleam
+query.like("email", "%@gmail.com")
+```
+
+### `ilike(field: String, pattern: String) -> Condition`
+
+Case-insensitive pattern match.
+
+```gleam
+query.ilike("name", "%john%")
+```
+
+### `is_null(field: String) -> Condition`
+
+NULL check (field IS NULL).
+
+```gleam
+query.is_null("deleted_at")
+```
+
+### `is_not_null(field: String) -> Condition`
+
+NOT NULL check (field IS NOT NULL).
+
+```gleam
+query.is_not_null("email")
+```
+
+### `in_list(field: String, values: List(Value)) -> Condition`
+
+IN clause (field IN (values)).
+
+```gleam
+query.in_list("status", [
+  ast.StringValue("active"),
+  ast.StringValue("pending"),
+])
+```
+
+### `between(field: String, low: Value, high: Value) -> Condition`
+
+BETWEEN clause (field BETWEEN low AND high).
+
+```gleam
+query.between("age", ast.IntValue(18), ast.IntValue(65))
+```
+
+### `and_where(conditions: List(Condition)) -> Condition`
+
+Combine conditions with AND.
+
+```gleam
+query.and_where([
+  query.eq("active", ast.BoolValue(True)),
+  query.gt("age", ast.IntValue(18)),
+])
+```
+
+### `or_where(conditions: List(Condition)) -> Condition`
+
+Combine conditions with OR.
+
+```gleam
+query.or_where([
+  query.eq("role", ast.StringValue("admin")),
+  query.eq("role", ast.StringValue("moderator")),
+])
+```
+
+### `not_where(condition: Condition) -> Condition`
+
+Negate a condition.
+
+```gleam
+query.not_where(query.eq("status", ast.StringValue("deleted")))
+```
+
+## cquill/query/ast
+
+Query AST types and constructors.
+
+### Value Types
+
+```gleam
+pub type Value {
+  IntValue(Int)
+  FloatValue(Float)
+  StringValue(String)
+  BoolValue(Bool)
+  NullValue
+  ParamValue(position: Int)
+  ListValue(List(Value))
+}
+```
+
+### `new_insert(table: String) -> InsertQuery(Nil)`
+
+Create a new INSERT query.
+
+```gleam
+let insert = ast.new_insert("users")
+```
+
+### `insert_columns(q: InsertQuery(a), columns: List(String)) -> InsertQuery(a)`
+
+Set columns to insert.
+
+```gleam
+ast.new_insert("users")
+|> ast.insert_columns(["email", "name"])
+```
+
+### `insert_values(q: InsertQuery(a), values: List(List(Value))) -> InsertQuery(a)`
+
+Set values to insert.
+
+```gleam
+ast.new_insert("users")
+|> ast.insert_columns(["email", "name"])
+|> ast.insert_values([[
+  ast.StringValue("alice@example.com"),
+  ast.StringValue("Alice"),
+]])
+```
+
+### `returning(q: InsertQuery(a), columns: List(String)) -> InsertQuery(a)`
+
+Specify RETURNING columns.
+
+```gleam
+ast.new_insert("users")
+|> ast.insert_columns(["email"])
+|> ast.insert_values([[ast.StringValue("test@example.com")]])
+|> ast.returning(["id", "created_at"])
+```
+
+### `new_update(table: String) -> UpdateQuery(Nil)`
+
+Create a new UPDATE query.
+
+```gleam
+let update = ast.new_update("users")
+```
+
+### `set(q: UpdateQuery(a), column: String, value: Value) -> UpdateQuery(a)`
+
+Set a column value.
+
+```gleam
+ast.new_update("users")
+|> ast.set("name", ast.StringValue("Alice"))
+|> ast.set("updated_at", ast.StringValue("2024-01-15"))
+```
+
+### `update_where(q: UpdateQuery(a), condition: Condition) -> UpdateQuery(a)`
+
+Add WHERE condition to UPDATE.
+
+```gleam
+ast.new_update("users")
+|> ast.set("active", ast.BoolValue(False))
+|> ast.update_where(query.eq("id", ast.IntValue(1)))
+```
+
+### `new_delete(table: String) -> DeleteQuery(Nil)`
+
+Create a new DELETE query.
+
+```gleam
+let delete = ast.new_delete("users")
+```
+
+### `delete_where(q: DeleteQuery(a), condition: Condition) -> DeleteQuery(a)`
+
+Add WHERE condition to DELETE.
+
+```gleam
+ast.new_delete("users")
+|> ast.delete_where(query.eq("id", ast.IntValue(1)))
+```
+
+## cquill/repo
+
+Repository module for executing queries.
+
+### `all(adapter, query: Query(a)) -> Result(List(Row), AdapterError)`
+
+Execute query and return all matching rows.
+
+```gleam
+case repo.all(adapter, query) {
+  Ok(rows) -> handle_rows(rows)
+  Error(e) -> handle_error(e)
+}
+```
+
+### `one(adapter, query: Query(a)) -> Result(Row, AdapterError)`
+
+Execute query and return exactly one row.
+
+Returns `Error(NotFound)` if no rows, `Error(TooManyRows(1, n))` if more than one.
+
+```gleam
+case repo.one(adapter, query) {
+  Ok(row) -> handle_row(row)
+  Error(error.NotFound) -> handle_not_found()
+  Error(e) -> handle_error(e)
+}
+```
+
+### `insert(adapter, query: InsertQuery(a)) -> Result(List(Row), AdapterError)`
+
+Execute INSERT and return RETURNING rows.
+
+```gleam
+case repo.insert(adapter, insert) {
+  Ok(rows) -> handle_inserted(rows)
+  Error(error.UniqueViolation(_, _)) -> handle_duplicate()
+  Error(e) -> handle_error(e)
+}
+```
+
+### `update(adapter, query: UpdateQuery(a)) -> Result(List(Row), AdapterError)`
+
+Execute UPDATE and return affected/RETURNING rows.
+
+```gleam
+case repo.update(adapter, update) {
+  Ok(rows) -> handle_updated(rows)
+  Error(e) -> handle_error(e)
+}
+```
+
+### `delete(adapter, query: DeleteQuery(a)) -> Result(Int, AdapterError)`
+
+Execute DELETE and return count of deleted rows.
+
+```gleam
+case repo.delete(adapter, delete) {
+  Ok(count) -> io.println("Deleted " <> int.to_string(count))
+  Error(e) -> handle_error(e)
+}
+```
+
+### `transaction(adapter, fn: fn(Tx) -> Result(a, e)) -> Result(a, e)`
+
+Execute operations in a transaction.
+
+```gleam
+repo.transaction(adapter, fn(tx) {
+  use user <- result.try(repo.insert(tx, user_insert))
+  use profile <- result.try(repo.insert(tx, profile_insert))
+  Ok(#(user, profile))
+})
+```
+
+## cquill/adapter/memory
+
+In-memory adapter for testing.
+
+### `new_store() -> MemoryStore`
+
+Create a new empty store.
+
+```gleam
+let store = memory.new_store()
+```
+
+### `create_table(store, name: String, columns: List(String)) -> MemoryStore`
+
+Create a table in the store.
+
+```gleam
+let store = memory.create_table(store, "users", ["id", "email", "name"])
+```
+
+### `insert_row(store, table: String, row: Dict(String, Value)) -> MemoryStore`
+
+Insert a row into a table.
+
+```gleam
+let store = memory.insert_row(store, "users", dict.from_list([
+  #("id", ast.IntValue(1)),
+  #("email", ast.StringValue("test@example.com")),
+]))
+```
+
+### `execute_select(store, query: Query(a)) -> Result(List(Row), AdapterError)`
+
+Execute a SELECT query.
+
+```gleam
+case memory.execute_select(store, query) {
+  Ok(rows) -> handle_rows(rows)
+  Error(e) -> handle_error(e)
+}
+```
+
+### `begin_transaction(store) -> #(MemoryStore, Transaction)`
+
+Start a transaction.
+
+```gleam
+let #(store, tx) = memory.begin_transaction(store)
+```
+
+### `commit_transaction(store, tx: Transaction) -> MemoryStore`
+
+Commit a transaction.
+
+```gleam
+let store = memory.commit_transaction(store, tx)
+```
+
+### `rollback_transaction(store, tx: Transaction) -> MemoryStore`
+
+Rollback a transaction.
+
+```gleam
+let store = memory.rollback_transaction(store, tx)
+```
+
+## cquill/telemetry
+
+Telemetry and observability module.
+
+### `start() -> Result(Nil, actor.StartError)`
+
+Start the telemetry server.
+
+```gleam
+let assert Ok(_) = telemetry.start()
+```
+
+### `attach(handler_id: String, events: List(EventType), handler: Handler) -> Result(Nil, AttachError)`
+
+Attach a telemetry handler.
+
+```gleam
+telemetry.attach(
+  "my-logger",
+  [telemetry.QueryStopType, telemetry.QueryExceptionType],
+  telemetry.logger_handler(),
+)
+```
+
+### `detach(handler_id: String) -> Result(Nil, DetachError)`
+
+Detach a handler.
+
+```gleam
+telemetry.detach("my-logger")
+```
+
+### `emit(event: Event, metadata: Metadata) -> Nil`
+
+Emit a telemetry event.
+
+```gleam
+telemetry.emit(
+  telemetry.QueryStop(telemetry.QueryStopEvent(...)),
+  telemetry.empty_metadata(),
+)
+```
+
+### `logger_handler() -> Handler`
+
+Built-in handler that logs queries.
+
+```gleam
+telemetry.attach("logger", [telemetry.QueryStopType], telemetry.logger_handler())
+```
+
+### `slow_query_handler(threshold_ms: Int) -> Handler`
+
+Built-in handler that logs slow queries.
+
+```gleam
+telemetry.attach("slow", [telemetry.QueryStopType], telemetry.slow_query_handler(100))
+```
+
+## cquill/dev
+
+Development mode module.
+
+### `enable() -> Result(Nil, DevError)`
+
+Enable dev mode with default configuration.
+
+```gleam
+dev.enable()
+```
+
+### `enable_with_config(config: DevConfig) -> Result(Nil, DevError)`
+
+Enable dev mode with custom configuration.
+
+```gleam
+dev.enable_with_config(dev.verbose_config())
+```
+
+### `disable() -> Result(Nil, DevError)`
+
+Disable dev mode.
+
+```gleam
+dev.disable()
+```
+
+### `is_enabled() -> Bool`
+
+Check if dev mode is enabled.
+
+```gleam
+case dev.is_enabled() {
+  True -> io.println("Dev mode active")
+  False -> io.println("Dev mode inactive")
+}
+```
+
+### `default_config() -> DevConfig`
+
+Get default dev configuration.
+
+### `minimal_config() -> DevConfig`
+
+Get minimal dev configuration (queries only).
+
+### `verbose_config() -> DevConfig`
+
+Get verbose dev configuration (all debugging).

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -1,0 +1,409 @@
+# Configuration Reference
+
+Configuration options for cquill and its components.
+
+## PostgreSQL Adapter Configuration
+
+### Connection Configuration
+
+```gleam
+import cquill/adapter/postgres
+
+let config = postgres.Config(
+  /// Database host
+  host: "localhost",
+
+  /// Database port
+  port: 5432,
+
+  /// Database name
+  database: "myapp_development",
+
+  /// Database user
+  user: "postgres",
+
+  /// Database password
+  password: "secret",
+
+  /// Connection pool size
+  pool_size: 10,
+
+  /// Enable SSL
+  ssl: False,
+
+  /// Connection timeout in milliseconds
+  connection_timeout: 5000,
+
+  /// Query timeout in milliseconds
+  query_timeout: 30000,
+)
+```
+
+### Configuration from URL
+
+```gleam
+// Parse DATABASE_URL format
+let config = postgres.parse_url("postgres://user:pass@host:5432/dbname")
+
+// With options
+let config = postgres.parse_url("postgres://user:pass@host:5432/dbname?pool_size=20&ssl=true")
+```
+
+### Configuration from Environment
+
+```gleam
+fn get_database_config() -> postgres.Config {
+  postgres.Config(
+    host: env.get("DB_HOST") |> result.unwrap("localhost"),
+    port: env.get("DB_PORT") |> result.try(int.parse) |> result.unwrap(5432),
+    database: env.get("DB_NAME") |> result.unwrap("myapp_dev"),
+    user: env.get("DB_USER") |> result.unwrap("postgres"),
+    password: env.get("DB_PASSWORD") |> result.unwrap(""),
+    pool_size: env.get("DB_POOL_SIZE") |> result.try(int.parse) |> result.unwrap(10),
+    ssl: env.get("DB_SSL") |> result.map(fn(s) { s == "true" }) |> result.unwrap(False),
+    connection_timeout: 5000,
+    query_timeout: 30000,
+  )
+}
+```
+
+### Pool Configuration
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `pool_size` | Int | 10 | Maximum number of connections |
+| `pool_overflow` | Int | 0 | Additional connections allowed under load |
+| `pool_timeout` | Int | 5000 | Time to wait for connection (ms) |
+| `idle_timeout` | Int | 300000 | Close idle connections after (ms) |
+
+### Timeout Configuration
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `connection_timeout` | Int | 5000 | Connection attempt timeout (ms) |
+| `query_timeout` | Int | 30000 | Query execution timeout (ms) |
+| `statement_timeout` | Int | None | PostgreSQL statement_timeout |
+
+### SSL Configuration
+
+```gleam
+let config = postgres.Config(
+  ...base_config,
+  ssl: True,
+  ssl_opts: Some(postgres.SslOpts(
+    verify: postgres.VerifyPeer,
+    cacertfile: "/path/to/ca.crt",
+    certfile: Some("/path/to/client.crt"),
+    keyfile: Some("/path/to/client.key"),
+  )),
+)
+```
+
+## Development Mode Configuration
+
+### DevConfig
+
+```gleam
+import cquill/dev
+
+let config = dev.DevConfig(
+  /// Enable/disable dev mode
+  enabled: True,
+
+  /// Log all queries
+  log_queries: True,
+
+  /// Include parameters in logs
+  log_params: True,
+
+  /// Threshold for slow query warnings (ms)
+  slow_query_threshold_ms: 100,
+
+  /// Enable pool statistics logging
+  log_pool_stats: False,
+
+  /// Pool stats logging interval (ms)
+  pool_stats_interval_ms: 10000,
+
+  /// Fields to mask in logs
+  mask_fields: ["password", "token", "secret", "key", "credential", "api_key"],
+
+  /// Pattern to replace masked values
+  mask_pattern: "[REDACTED]",
+
+  /// Enable EXPLAIN output
+  explain_queries: False,
+)
+```
+
+### Preset Configurations
+
+#### Default Configuration
+
+Balanced settings for development:
+
+```gleam
+let config = dev.default_config()
+// DevConfig(
+//   enabled: True,
+//   log_queries: True,
+//   log_params: True,
+//   slow_query_threshold_ms: 100,
+//   log_pool_stats: False,
+//   pool_stats_interval_ms: 10000,
+//   mask_fields: ["password", "token", "secret", "key", "credential", "api_key"],
+//   mask_pattern: "[REDACTED]",
+//   explain_queries: False,
+// )
+```
+
+#### Minimal Configuration
+
+Query logging only, no parameters:
+
+```gleam
+let config = dev.minimal_config()
+// DevConfig(
+//   enabled: True,
+//   log_queries: True,
+//   log_params: False,
+//   slow_query_threshold_ms: 500,
+//   log_pool_stats: False,
+//   ...
+// )
+```
+
+#### Verbose Configuration
+
+All debugging enabled:
+
+```gleam
+let config = dev.verbose_config()
+// DevConfig(
+//   enabled: True,
+//   log_queries: True,
+//   log_params: True,
+//   slow_query_threshold_ms: 50,
+//   log_pool_stats: True,
+//   pool_stats_interval_ms: 5000,
+//   explain_queries: True,
+//   ...
+// )
+```
+
+### Environment Variable Activation
+
+Enable dev mode via environment variable:
+
+```bash
+# Enable dev mode
+CQUILL_DEV=1 gleam run
+
+# Accepted values: 1, true, yes, on
+```
+
+```gleam
+// At application startup
+dev.enable_from_env()
+```
+
+## Telemetry Configuration
+
+### Attaching Handlers
+
+```gleam
+import cquill/telemetry
+
+// Start telemetry server
+telemetry.start()
+
+// Attach handlers
+telemetry.attach(
+  "my-logger",        // Handler ID
+  [                   // Event types to subscribe
+    telemetry.QueryStopType,
+    telemetry.QueryExceptionType,
+  ],
+  my_handler_fn,      // Handler function
+)
+```
+
+### Event Types
+
+| Event Type | Description |
+|------------|-------------|
+| `QueryStartType` | Query execution started |
+| `QueryStopType` | Query execution completed |
+| `QueryExceptionType` | Query execution failed |
+| `PoolCheckoutType` | Connection checked out from pool |
+| `PoolCheckinType` | Connection returned to pool |
+| `PoolTimeoutType` | Pool checkout timed out |
+| `TransactionStartType` | Transaction started |
+| `TransactionCommitType` | Transaction committed |
+| `TransactionRollbackType` | Transaction rolled back |
+| `SavepointCreateType` | Savepoint created |
+| `SavepointRollbackType` | Rolled back to savepoint |
+| `SavepointReleaseType` | Savepoint released |
+| `BatchStartType` | Batch operation started |
+| `BatchStopType` | Batch operation completed |
+
+### Built-in Handlers
+
+```gleam
+// Logger handler - logs queries
+telemetry.attach("logger", [telemetry.QueryStopType], telemetry.logger_handler())
+
+// Slow query handler - logs queries exceeding threshold
+telemetry.attach("slow", [telemetry.QueryStopType], telemetry.slow_query_handler(100))
+
+// Debug handler - logs all events
+telemetry.attach("debug", telemetry.all_event_types(), telemetry.debug_handler())
+
+// Metrics handler - custom callbacks
+telemetry.attach("metrics", [telemetry.QueryStopType], telemetry.metrics_handler(
+  on_query_complete: fn(query, duration_us, row_count) { ... },
+  on_query_error: fn(error_type) { ... },
+  on_pool_timeout: fn(pool_name) { ... },
+))
+```
+
+## Memory Adapter Configuration
+
+The memory adapter requires no configuration:
+
+```gleam
+import cquill/adapter/memory
+
+// Create a new store
+let store = memory.new_store()
+
+// Create tables as needed
+let store = store
+  |> memory.create_table("users", ["id", "email", "name"])
+  |> memory.create_table("posts", ["id", "user_id", "title", "body"])
+```
+
+## Code Generation Configuration
+
+### Generator Config
+
+```gleam
+import cquill/codegen/generator
+
+let config = generator.GeneratorConfig(
+  /// Output directory for generated files
+  output_dir: "src/generated",
+
+  /// Module prefix for generated modules
+  module_prefix: "myapp/schema",
+
+  /// Tables to include (empty = all)
+  include_tables: [],
+
+  /// Tables to exclude
+  exclude_tables: ["schema_migrations", "_prisma_migrations"],
+
+  /// Generate decoders
+  generate_decoders: True,
+
+  /// Generate encoders
+  generate_encoders: True,
+
+  /// Generate query helpers
+  generate_queries: True,
+)
+```
+
+### CLI Configuration
+
+Via command line:
+
+```bash
+gleam run -m cquill_cli generate \
+  --output-dir src/generated \
+  --module-prefix myapp/schema \
+  --exclude schema_migrations
+```
+
+Via gleam.toml:
+
+```toml
+[cquill]
+output_dir = "src/generated"
+module_prefix = "myapp/schema"
+exclude_tables = ["schema_migrations"]
+```
+
+## Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `DATABASE_URL` | PostgreSQL connection URL | - |
+| `DB_HOST` | Database host | localhost |
+| `DB_PORT` | Database port | 5432 |
+| `DB_NAME` | Database name | - |
+| `DB_USER` | Database user | postgres |
+| `DB_PASSWORD` | Database password | - |
+| `DB_POOL_SIZE` | Connection pool size | 10 |
+| `DB_SSL` | Enable SSL | false |
+| `CQUILL_DEV` | Enable dev mode | - |
+
+## Production Recommendations
+
+### Connection Pool
+
+```gleam
+let config = postgres.Config(
+  ...base_config,
+  // Size based on: (2 * CPU cores) + spindle count
+  pool_size: 20,
+
+  // Allow some overflow for burst traffic
+  pool_overflow: 5,
+
+  // Don't wait too long for connections
+  pool_timeout: 5000,
+
+  // Clean up idle connections
+  idle_timeout: 300000,  // 5 minutes
+)
+```
+
+### Timeouts
+
+```gleam
+let config = postgres.Config(
+  ...base_config,
+  // Fail fast on connection issues
+  connection_timeout: 5000,
+
+  // Reasonable query timeout
+  query_timeout: 30000,
+
+  // PostgreSQL-level timeout
+  statement_timeout: 25000,
+)
+```
+
+### SSL
+
+```gleam
+let config = postgres.Config(
+  ...base_config,
+  ssl: True,
+  ssl_opts: Some(postgres.SslOpts(
+    verify: postgres.VerifyPeer,
+    cacertfile: "/etc/ssl/certs/ca-certificates.crt",
+  )),
+)
+```
+
+### Disable Dev Mode
+
+```gleam
+// Don't enable dev mode in production
+case env.get("GLEAM_ENV") {
+  Ok("production") -> Nil
+  _ -> dev.enable_from_env()
+}
+```

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -1,0 +1,555 @@
+# Errors Reference
+
+Complete reference for all error types in cquill with causes and solutions.
+
+## AdapterError
+
+The main error type returned by all adapter operations.
+
+```gleam
+import cquill/error
+
+case repo.all(adapter, query) {
+  Ok(rows) -> handle_success(rows)
+  Error(e) -> {
+    io.println("Error: " <> error.format(e))
+    handle_error(e)
+  }
+}
+```
+
+## Not Found Errors
+
+### NotFound
+
+A query expected to return a row returned none.
+
+```gleam
+Error(error.NotFound)
+```
+
+**When it occurs:**
+- `repo.one()` with no matching rows
+- Getting a record by ID that doesn't exist
+
+**How to handle:**
+
+```gleam
+case repo.one(adapter, user_by_id(id)) {
+  Ok(user) -> Ok(user)
+  Error(error.NotFound) -> {
+    io.println("User " <> int.to_string(id) <> " not found")
+    Error("User not found")
+  }
+  Error(e) -> Error(error.format(e))
+}
+```
+
+### TooManyRows
+
+A query expected one row but returned multiple.
+
+```gleam
+Error(error.TooManyRows(expected: Int, got: Int))
+```
+
+**When it occurs:**
+- `repo.one()` returns more than one row
+
+**How to handle:**
+
+```gleam
+case repo.one(adapter, query) {
+  Ok(row) -> Ok(row)
+  Error(error.TooManyRows(expected, got)) -> {
+    io.println("Expected " <> int.to_string(expected) <> ", got " <> int.to_string(got))
+    // Usually indicates a bug in query or data
+    Error("Multiple matches found")
+  }
+  Error(e) -> Error(error.format(e))
+}
+```
+
+## Connection Errors
+
+### ConnectionFailed
+
+Failed to establish a database connection.
+
+```gleam
+Error(error.ConnectionFailed(reason: String))
+```
+
+**When it occurs:**
+- Database server is down
+- Invalid connection credentials
+- Network issues
+
+**How to handle:**
+
+```gleam
+case postgres.connect(config) {
+  Ok(pool) -> use_pool(pool)
+  Error(error.ConnectionFailed(reason)) -> {
+    io.println_error("Cannot connect to database: " <> reason)
+    // Retry with backoff or fail gracefully
+  }
+  Error(e) -> handle_error(e)
+}
+```
+
+### ConnectionTimeout
+
+Connection attempt timed out.
+
+```gleam
+Error(error.ConnectionTimeout)
+```
+
+**When it occurs:**
+- Database is slow to respond
+- Network latency issues
+
+**How to handle:**
+
+```gleam
+case result {
+  Error(error.ConnectionTimeout) -> {
+    // Retry with increased timeout or fail
+    io.println_error("Connection timeout - database may be overloaded")
+  }
+  _ -> ...
+}
+```
+
+### PoolExhausted
+
+All connections in the pool are in use.
+
+```gleam
+Error(error.PoolExhausted)
+```
+
+**When it occurs:**
+- Too many concurrent database operations
+- Pool size too small for workload
+- Long-running queries holding connections
+
+**How to handle:**
+
+```gleam
+case result {
+  Error(error.PoolExhausted) -> {
+    io.println_error("Connection pool exhausted")
+    // Consider: increase pool size, add connection timeout
+    // Or: implement request queuing/backpressure
+  }
+  _ -> ...
+}
+```
+
+### ConnectionLost
+
+Connection was lost during operation.
+
+```gleam
+Error(error.ConnectionLost(reason: String))
+```
+
+**When it occurs:**
+- Database server restarted
+- Network interruption
+- Idle connection timeout
+
+**How to handle:**
+
+```gleam
+case result {
+  Error(error.ConnectionLost(reason)) -> {
+    io.println_error("Connection lost: " <> reason)
+    // Retry the operation with a new connection
+  }
+  _ -> ...
+}
+```
+
+## Query Errors
+
+### QueryFailed
+
+Query execution failed.
+
+```gleam
+Error(error.QueryFailed(message: String, code: Option(String)))
+```
+
+**When it occurs:**
+- SQL syntax error
+- Invalid table or column name
+- Invalid data type
+
+**How to handle:**
+
+```gleam
+case result {
+  Error(error.QueryFailed(message, Some(code))) -> {
+    io.println_error("Query failed [" <> code <> "]: " <> message)
+  }
+  Error(error.QueryFailed(message, None)) -> {
+    io.println_error("Query failed: " <> message)
+  }
+  _ -> ...
+}
+```
+
+### DecodeFailed
+
+Failed to decode a result row.
+
+```gleam
+Error(error.DecodeFailed(
+  row: Int,
+  column: String,
+  expected: String,
+  got: String,
+))
+```
+
+**When it occurs:**
+- Column type mismatch
+- Unexpected NULL value
+- Data corruption
+
+**How to handle:**
+
+```gleam
+case result {
+  Error(error.DecodeFailed(row, column, expected, got)) -> {
+    io.println_error(
+      "Decode error at row " <> int.to_string(row)
+      <> ", column '" <> column <> "': expected " <> expected <> ", got " <> got
+    )
+  }
+  _ -> ...
+}
+```
+
+### Timeout
+
+Operation timed out.
+
+```gleam
+Error(error.Timeout)
+```
+
+**When it occurs:**
+- Query took too long to execute
+- Statement timeout exceeded
+
+**How to handle:**
+
+```gleam
+case result {
+  Error(error.Timeout) -> {
+    io.println_error("Query timeout - consider optimizing the query")
+  }
+  _ -> ...
+}
+```
+
+## Constraint Violations
+
+### UniqueViolation
+
+Unique constraint violated.
+
+```gleam
+Error(error.UniqueViolation(constraint: String, detail: String))
+```
+
+**When it occurs:**
+- Inserting duplicate value in unique column
+- Updating to create duplicate
+
+**How to handle:**
+
+```gleam
+case repo.insert(adapter, user_insert) {
+  Ok(rows) -> Ok(rows)
+  Error(error.UniqueViolation(constraint, detail)) -> {
+    case constraint {
+      "users_email_key" -> Error("Email already in use")
+      "users_username_key" -> Error("Username already taken")
+      _ -> Error("Duplicate value: " <> detail)
+    }
+  }
+  Error(e) -> Error(error.format(e))
+}
+```
+
+### ForeignKeyViolation
+
+Foreign key constraint violated.
+
+```gleam
+Error(error.ForeignKeyViolation(constraint: String, detail: String))
+```
+
+**When it occurs:**
+- Inserting with non-existent foreign key
+- Deleting record referenced by others
+
+**How to handle:**
+
+```gleam
+case result {
+  Error(error.ForeignKeyViolation(constraint, detail)) -> {
+    case constraint {
+      "orders_customer_id_fkey" -> Error("Customer does not exist")
+      "order_items_order_id_fkey" -> Error("Order does not exist")
+      _ -> Error("Foreign key violation: " <> detail)
+    }
+  }
+  _ -> ...
+}
+```
+
+### CheckViolation
+
+Check constraint violated.
+
+```gleam
+Error(error.CheckViolation(constraint: String, detail: String))
+```
+
+**When it occurs:**
+- Value doesn't satisfy CHECK constraint
+
+**How to handle:**
+
+```gleam
+case result {
+  Error(error.CheckViolation(constraint, detail)) -> {
+    case constraint {
+      "positive_price" -> Error("Price must be positive")
+      "valid_age" -> Error("Age must be between 0 and 150")
+      _ -> Error("Validation failed: " <> detail)
+    }
+  }
+  _ -> ...
+}
+```
+
+### NotNullViolation
+
+NOT NULL constraint violated.
+
+```gleam
+Error(error.NotNullViolation(column: String))
+```
+
+**When it occurs:**
+- Inserting NULL into NOT NULL column
+- Updating to NULL
+
+**How to handle:**
+
+```gleam
+case result {
+  Error(error.NotNullViolation(column)) -> {
+    Error("Missing required field: " <> column)
+  }
+  _ -> ...
+}
+```
+
+### ConstraintViolation
+
+Generic constraint violation.
+
+```gleam
+Error(error.ConstraintViolation(constraint: String, detail: String))
+```
+
+**When it occurs:**
+- Any constraint not covered by specific types
+
+## Data Errors
+
+### StaleData
+
+Optimistic locking conflict.
+
+```gleam
+Error(error.StaleData(expected_version: String, actual_version: String))
+```
+
+**When it occurs:**
+- Concurrent modification detected
+- Version mismatch in optimistic locking
+
+**How to handle:**
+
+```gleam
+case result {
+  Error(error.StaleData(expected, actual)) -> {
+    io.println("Conflict: expected version " <> expected <> ", found " <> actual)
+    // Reload data and retry, or ask user to resolve
+    Error("Data was modified by another user")
+  }
+  _ -> ...
+}
+```
+
+### DataIntegrityError
+
+Data integrity error.
+
+```gleam
+Error(error.DataIntegrityError(message: String))
+```
+
+**When it occurs:**
+- Invalid data state
+- Inconsistent data detected
+
+## Capability Errors
+
+### NotSupported
+
+Adapter doesn't support this operation.
+
+```gleam
+Error(error.NotSupported(operation: String))
+```
+
+**When it occurs:**
+- Using feature not supported by adapter
+- PostgreSQL-specific feature with memory adapter
+
+**How to handle:**
+
+```gleam
+case result {
+  Error(error.NotSupported(operation)) -> {
+    io.println_error("Operation not supported: " <> operation)
+    // Fall back to alternative approach
+  }
+  _ -> ...
+}
+```
+
+## Adapter-Specific Errors
+
+### AdapterSpecific
+
+Errors specific to an adapter.
+
+```gleam
+Error(error.AdapterSpecific(code: String, message: String))
+```
+
+**When it occurs:**
+- Backend-specific error
+- Errors not mapped to standard types
+
+**How to handle:**
+
+```gleam
+case result {
+  Error(error.AdapterSpecific(code, message)) -> {
+    io.println_error("Adapter error [" <> code <> "]: " <> message)
+  }
+  _ -> ...
+}
+```
+
+## Error Formatting
+
+### `error.format(e: AdapterError) -> String`
+
+Format error for display.
+
+```gleam
+case result {
+  Error(e) -> {
+    let message = error.format(e)
+    io.println_error(message)
+  }
+  _ -> ...
+}
+```
+
+### `error.is_recoverable(e: AdapterError) -> Bool`
+
+Check if error is recoverable (retry may help).
+
+```gleam
+case result {
+  Error(e) if error.is_recoverable(e) -> {
+    // Retry with backoff
+    retry_operation()
+  }
+  Error(e) -> {
+    // Don't retry
+    fail_permanently(e)
+  }
+  Ok(v) -> Ok(v)
+}
+```
+
+### `error.to_http_status(e: AdapterError) -> Int`
+
+Map error to HTTP status code (useful for APIs).
+
+```gleam
+case result {
+  Error(e) -> {
+    let status = error.to_http_status(e)
+    let body = error.format(e)
+    http.response(status, body)
+  }
+  Ok(data) -> http.response(200, encode(data))
+}
+```
+
+## Best Practices
+
+### 1. Handle Specific Errors First
+
+```gleam
+case result {
+  // Handle specific cases
+  Error(error.NotFound) -> handle_not_found()
+  Error(error.UniqueViolation(_, _)) -> handle_duplicate()
+  Error(error.ForeignKeyViolation(_, _)) -> handle_invalid_reference()
+  // Then catch-all
+  Error(e) -> handle_unexpected(e)
+  Ok(v) -> handle_success(v)
+}
+```
+
+### 2. Log Errors with Context
+
+```gleam
+case repo.insert(adapter, insert) {
+  Error(e) -> {
+    io.println_error("[UserService.create] Failed to create user: " <> error.format(e))
+    Error(e)
+  }
+  Ok(v) -> Ok(v)
+}
+```
+
+### 3. Return User-Friendly Messages
+
+```gleam
+fn user_friendly_error(e: error.AdapterError) -> String {
+  case e {
+    error.UniqueViolation("users_email_key", _) -> "This email is already registered"
+    error.NotNullViolation("name") -> "Name is required"
+    error.ForeignKeyViolation(_, _) -> "Invalid reference"
+    _ -> "An unexpected error occurred"
+  }
+}
+```

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -1,0 +1,506 @@
+# Types Reference
+
+Complete reference for all public types in cquill.
+
+## Query Types
+
+### Query
+
+Represents a SELECT query AST.
+
+```gleam
+pub type Query(schema) {
+  Query(
+    source: Source,
+    select: Select,
+    wheres: List(Where),
+    order_bys: List(OrderBy),
+    limit: Option(Int),
+    offset: Option(Int),
+    joins: List(Join),
+    distinct: Bool,
+    group_bys: List(String),
+    havings: List(Where),
+  )
+}
+```
+
+### InsertQuery
+
+Represents an INSERT query AST.
+
+```gleam
+pub type InsertQuery(schema) {
+  InsertQuery(
+    table: String,
+    schema_name: Option(String),
+    columns: List(String),
+    values: List(List(Value)),
+    on_conflict: Option(OnConflict),
+    returning: List(String),
+  )
+}
+```
+
+### UpdateQuery
+
+Represents an UPDATE query AST.
+
+```gleam
+pub type UpdateQuery(schema) {
+  UpdateQuery(
+    table: String,
+    schema_name: Option(String),
+    sets: List(SetClause),
+    wheres: List(Where),
+    returning: List(String),
+  )
+}
+```
+
+### DeleteQuery
+
+Represents a DELETE query AST.
+
+```gleam
+pub type DeleteQuery(schema) {
+  DeleteQuery(
+    table: String,
+    schema_name: Option(String),
+    wheres: List(Where),
+    returning: List(String),
+  )
+}
+```
+
+## Value Types
+
+### Value
+
+Represents a value in a query.
+
+```gleam
+pub type Value {
+  /// Integer value
+  IntValue(Int)
+  /// Float value
+  FloatValue(Float)
+  /// String value
+  StringValue(String)
+  /// Boolean value
+  BoolValue(Bool)
+  /// NULL value
+  NullValue
+  /// Positional parameter ($1, $2, etc.)
+  ParamValue(position: Int)
+  /// List of values (for IN clauses)
+  ListValue(List(Value))
+}
+```
+
+## Condition Types
+
+### Condition
+
+Represents a WHERE/HAVING condition.
+
+```gleam
+pub type Condition {
+  /// field = value
+  Eq(field: String, value: Value)
+  /// field != value
+  NotEq(field: String, value: Value)
+  /// field > value
+  Gt(field: String, value: Value)
+  /// field >= value
+  Gte(field: String, value: Value)
+  /// field < value
+  Lt(field: String, value: Value)
+  /// field <= value
+  Lte(field: String, value: Value)
+  /// field IN (values...)
+  In(field: String, values: List(Value))
+  /// field NOT IN (values...)
+  NotIn(field: String, values: List(Value))
+  /// field LIKE pattern
+  Like(field: String, pattern: String)
+  /// field NOT LIKE pattern
+  NotLike(field: String, pattern: String)
+  /// field ILIKE pattern
+  ILike(field: String, pattern: String)
+  /// field IS NULL
+  IsNull(field: String)
+  /// field IS NOT NULL
+  IsNotNull(field: String)
+  /// field BETWEEN low AND high
+  Between(field: String, low: Value, high: Value)
+  /// Combined conditions (AND)
+  And(List(Condition))
+  /// Alternative conditions (OR)
+  Or(List(Condition))
+  /// Negated condition
+  Not(Condition)
+  /// Raw SQL condition
+  Raw(sql: String, params: List(Value))
+}
+```
+
+## Source Types
+
+### Source
+
+Represents the FROM source of a query.
+
+```gleam
+pub type Source {
+  /// Query from a table
+  TableSource(table: String, schema_name: Option(String))
+  /// Query from a subquery
+  SubquerySource(query: Query(Nil))
+}
+```
+
+## Select Types
+
+### Select
+
+Represents what to SELECT.
+
+```gleam
+pub type Select {
+  /// SELECT *
+  SelectAll
+  /// SELECT specific fields
+  SelectFields(List(String))
+  /// SELECT expressions
+  SelectExpr(List(SelectExpression))
+}
+```
+
+### SelectExpression
+
+A select expression with optional alias.
+
+```gleam
+pub type SelectExpression {
+  SelectExpression(expr: Expr, alias: Option(String))
+}
+```
+
+### Expr
+
+Expression types for SELECT.
+
+```gleam
+pub type Expr {
+  /// Column reference
+  ColumnExpr(field: String)
+  /// Qualified column (table.field)
+  QualifiedColumnExpr(table: String, field: String)
+  /// Literal value
+  LiteralExpr(value: Value)
+  /// Aggregate function
+  AggregateExpr(func: AggregateFunc, field: String)
+  /// Function call
+  FunctionExpr(name: String, args: List(Expr))
+  /// Binary operation
+  BinaryExpr(left: Expr, op: BinaryOp, right: Expr)
+}
+```
+
+### AggregateFunc
+
+Aggregate functions.
+
+```gleam
+pub type AggregateFunc {
+  Count
+  Sum
+  Avg
+  Min
+  Max
+  CountDistinct
+}
+```
+
+## Order Types
+
+### OrderBy
+
+ORDER BY clause.
+
+```gleam
+pub type OrderBy {
+  OrderBy(field: String, direction: Direction, nulls: NullsOrder)
+}
+```
+
+### Direction
+
+Sort direction.
+
+```gleam
+pub type Direction {
+  Asc
+  Desc
+}
+```
+
+### NullsOrder
+
+NULL ordering preference.
+
+```gleam
+pub type NullsOrder {
+  NullsDefault
+  NullsFirst
+  NullsLast
+}
+```
+
+## Join Types
+
+### Join
+
+JOIN clause.
+
+```gleam
+pub type Join {
+  Join(
+    join_type: JoinType,
+    table: String,
+    table_alias: Option(String),
+    on: Condition,
+  )
+}
+```
+
+### JoinType
+
+Types of JOIN.
+
+```gleam
+pub type JoinType {
+  InnerJoin
+  LeftJoin
+  RightJoin
+  FullJoin
+  CrossJoin
+}
+```
+
+## Conflict Types
+
+### OnConflict
+
+Conflict handling for INSERT.
+
+```gleam
+pub type OnConflict {
+  /// ON CONFLICT DO NOTHING
+  DoNothing
+  /// ON CONFLICT (columns) DO UPDATE SET ...
+  DoUpdate(conflict_columns: List(String), update_columns: List(String))
+  /// ON CONFLICT ON CONSTRAINT name DO NOTHING
+  DoNothingOnConstraint(constraint_name: String)
+  /// ON CONFLICT ON CONSTRAINT name DO UPDATE SET ...
+  DoUpdateOnConstraint(constraint_name: String, update_columns: List(String))
+}
+```
+
+## Schema Types
+
+### Schema
+
+Schema metadata.
+
+```gleam
+pub type Schema {
+  Schema(
+    table_name: String,
+    schema_name: Option(String),
+    fields: List(Field),
+  )
+}
+```
+
+### Field
+
+Field metadata.
+
+```gleam
+pub type Field {
+  Field(
+    name: String,
+    field_type: FieldType,
+    constraints: List(Constraint),
+    default: Option(String),
+  )
+}
+```
+
+### FieldType
+
+Field data types.
+
+```gleam
+pub type FieldType {
+  Integer
+  BigInt
+  Float
+  Decimal(precision: Int, scale: Int)
+  String
+  Text
+  Boolean
+  Timestamp
+  TimestampTz
+  Date
+  Time
+  Uuid
+  Json
+  Jsonb
+  Binary
+  Array(element_type: FieldType)
+}
+```
+
+### Constraint
+
+Field constraints.
+
+```gleam
+pub type Constraint {
+  NotNull
+  Unique
+  PrimaryKey
+  AutoIncrement
+  Check(expression: String)
+  References(table: String, column: String)
+  Default(value: String)
+}
+```
+
+## Telemetry Types
+
+### Event
+
+Telemetry events.
+
+```gleam
+pub type Event {
+  QueryStart(QueryStartEvent)
+  QueryStop(QueryStopEvent)
+  QueryException(QueryExceptionEvent)
+  PoolCheckout(PoolCheckoutEvent)
+  PoolCheckin(PoolCheckinEvent)
+  PoolTimeout(PoolTimeoutEvent)
+  TransactionStart(TransactionStartEvent)
+  TransactionCommit(TransactionCommitEvent)
+  TransactionRollback(TransactionRollbackEvent)
+  SavepointCreate(SavepointCreateEvent)
+  SavepointRollback(SavepointRollbackEvent)
+  SavepointRelease(SavepointReleaseEvent)
+  BatchStart(BatchStartEvent)
+  BatchStop(BatchStopEvent)
+}
+```
+
+### EventType
+
+Event type enumeration.
+
+```gleam
+pub type EventType {
+  QueryStartType
+  QueryStopType
+  QueryExceptionType
+  PoolCheckoutType
+  PoolCheckinType
+  PoolTimeoutType
+  TransactionStartType
+  TransactionCommitType
+  TransactionRollbackType
+  SavepointCreateType
+  SavepointRollbackType
+  SavepointReleaseType
+  BatchStartType
+  BatchStopType
+}
+```
+
+### Handler
+
+Telemetry handler function type.
+
+```gleam
+pub type Handler =
+  fn(Event, Metadata) -> Nil
+```
+
+### Metadata
+
+Event metadata.
+
+```gleam
+pub type Metadata =
+  Dict(String, Dynamic)
+```
+
+## Dev Mode Types
+
+### DevConfig
+
+Development mode configuration.
+
+```gleam
+pub type DevConfig {
+  DevConfig(
+    enabled: Bool,
+    log_queries: Bool,
+    log_params: Bool,
+    slow_query_threshold_ms: Int,
+    log_pool_stats: Bool,
+    pool_stats_interval_ms: Int,
+    mask_fields: List(String),
+    mask_pattern: String,
+    explain_queries: Bool,
+  )
+}
+```
+
+### PoolStats
+
+Pool statistics.
+
+```gleam
+pub type PoolStats {
+  PoolStats(
+    pool_name: String,
+    size: Int,
+    in_use: Int,
+    available: Int,
+    waiting: Int,
+    total_checkouts: Int,
+    total_timeouts: Int,
+  )
+}
+```
+
+## Row Type
+
+Query results are returned as dictionaries:
+
+```gleam
+pub type Row =
+  Dict(String, Value)
+```
+
+Access values:
+
+```gleam
+case dict.get(row, "email") {
+  Ok(ast.StringValue(email)) -> email
+  Ok(_) -> "unexpected type"
+  Error(_) -> "field not found"
+}
+```


### PR DESCRIPTION
## Summary

- Adds complete documentation structure covering all aspects of cquill
- Provides practical examples and code snippets throughout
- Includes recipes for common patterns (pagination, soft-delete, audit-log, multi-tenant)

### Documentation Structure

```
docs/
├── README.md              # Main documentation index
├── getting-started.md     # Installation and first steps
├── concepts/
│   ├── schemas.md         # Schema definitions and field types
│   ├── queries.md         # Query-as-data approach
│   ├── repo.md            # Repository pattern
│   └── adapters.md        # Adapter abstraction
├── guides/
│   ├── crud.md            # CRUD operations
│   ├── queries.md         # Advanced queries
│   ├── transactions.md    # Transactions and savepoints
│   └── testing.md         # Testing strategies
├── reference/
│   ├── api.md             # Complete API reference
│   ├── types.md           # Type definitions
│   ├── errors.md          # Error handling
│   └── config.md          # Configuration options
└── recipes/
    ├── pagination.md      # Pagination patterns
    ├── soft-delete.md     # Soft delete pattern
    ├── audit-log.md       # Audit logging
    └── multi-tenant.md    # Multi-tenant applications
```

### Documentation Examples

**Getting Started - First Query:**
```gleam
import cquill/adapter/memory
import cquill/query
import cquill/query/ast
import cquill/repo

pub fn main() {
  // Create an in-memory store
  let store = memory.new_store()
    |> memory.create_table("users", ["id", "email", "name"])
  
  // Insert a user
  let insert = 
    ast.new_insert("users")
    |> ast.insert_columns(["id", "email", "name"])
    |> ast.insert_values([[
      ast.IntValue(1),
      ast.StringValue("alice@example.com"),
      ast.StringValue("Alice"),
    ]])
  
  let assert Ok(_) = repo.insert(store, insert)
  
  // Query users
  let users_query = 
    query.from("users")
    |> query.where(query.eq("email", ast.StringValue("alice@example.com")))
  
  case repo.one(store, users_query) {
    Ok(user) -> io.println("Found: " <> string.inspect(user))
    Error(_) -> io.println("Not found")
  }
}
```

**Query Building - Composable Filters:**
```gleam
// Base query
let base = query.from("products")

// Add filters based on conditions
let filtered = case category {
  Some(cat) -> base |> query.where(query.eq("category", ast.StringValue(cat)))
  None -> base
}

// Chain additional conditions
let final = filtered
  |> query.where(query.gte("price", ast.FloatValue(min_price)))
  |> query.where(query.lte("price", ast.FloatValue(max_price)))
  |> query.order_by_asc("price")
  |> query.limit(20)
```

**Transactions with Savepoints:**
```gleam
repo.transaction(adapter, fn(tx) {
  use user <- result.try(create_user(tx, user_data))
  
  // Create savepoint before risky operation
  repo.savepoint(tx, "before_notification", fn(sp) {
    case send_welcome_email(user) {
      Ok(_) -> Ok(Nil)
      Error(_) -> {
        // Rollback notification, but keep user
        repo.rollback_to_savepoint(sp)
        Ok(Nil)
      }
    }
  })
  
  Ok(user)
})
```

**Pagination Recipe:**
```gleam
pub fn paginate_by_cursor(
  adapter,
  base_query: query.Query(a),
  cursor: Option(Int),
  limit: Int,
) -> Result(CursorPage(Row, Int), error.AdapterError) {
  let query = case cursor {
    Some(last_id) ->
      base_query
      |> query.where(query.gt("id", ast.IntValue(last_id)))
    None -> base_query
  }

  let query =
    query
    |> query.order_by_asc("id")
    |> query.limit(limit + 1)

  use rows <- result.try(repo.all(adapter, query))

  let has_more = list.length(rows) > limit
  let items = list.take(rows, limit)
  
  // ... extract next_cursor from last item
  
  Ok(CursorPage(items: items, next_cursor: next_cursor, has_more: has_more))
}
```

## Test plan

- [x] All documentation files are valid markdown
- [x] Code examples follow cquill API patterns
- [x] Documentation structure matches issue requirements
- [ ] Review documentation for accuracy and completeness

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)