### PR TITLE
feat: implement watch mode for code generation

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -334,10 +334,54 @@ module_prefix = "myapp/schema"
 exclude_tables = ["schema_migrations"]
 ```
 
+### Watch Mode
+
+Watch mode automatically regenerates code when the database schema changes. This is useful during development when you're frequently modifying your schema.
+
+```bash
+# Basic watch mode (polls every 5 seconds)
+cquill generate --database-url $DATABASE_URL --watch
+
+# Watch with custom poll interval (2 seconds)
+cquill generate --database-url $DATABASE_URL --watch --poll-interval 2000
+
+# Watch with verbose output to see when changes are detected
+cquill generate --database-url $DATABASE_URL --watch --verbose
+```
+
+Watch mode features:
+- **Automatic change detection**: Compares schema fingerprints to detect changes
+- **Configurable polling**: Set custom poll intervals with `--poll-interval <ms>`
+- **Graceful shutdown**: Press Ctrl+C to stop watching
+- **Status messages**: Shows timestamps and what changed when regenerating
+- **Error resilience**: Continues watching even if generation fails
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--watch, -w` | Flag | false | Enable watch mode |
+| `--poll-interval` | Int | 5000 | Polling interval in milliseconds |
+
+Example output:
+```
+cquill watch mode starting...
+
+Initial generation complete: 5 files generated
+
+Watching for schema changes...
+Poll interval: 5000ms
+Press Ctrl+C to stop.
+
+[2024-01-15 10:30:25] Schema change detected, regenerating...
+  Tables: 6
+  Enums: 2
+[2024-01-15 10:30:25] Regenerated 6 files
+```
+
 ## Environment Variables
 
 | Variable | Description | Default |
 |----------|-------------|---------|
+| `CQUILL_DATABASE_URL` | Database URL for CLI tools | - |
 | `DATABASE_URL` | PostgreSQL connection URL | - |
 | `DB_HOST` | Database host | localhost |
 | `DB_PORT` | Database port | 5432 |

--- a/src/cquill_crypto_ffi.erl
+++ b/src/cquill_crypto_ffi.erl
@@ -1,0 +1,6 @@
+-module(cquill_crypto_ffi).
+-export([hash_sha256/1]).
+
+%% Hash a string using SHA-256
+hash_sha256(String) when is_binary(String) ->
+    crypto:hash(sha256, String).


### PR DESCRIPTION
## Summary

- Implements the `--watch` flag for the CLI generate command that monitors database schema for changes and automatically regenerates code
- Adds configurable polling interval via `--poll-interval <ms>` option (default: 5 seconds)
- Uses SHA-256 fingerprinting for efficient schema change detection
- Provides timestamp-based status messages showing when changes are detected and files regenerated

## Changes

- **src/cquill/cli/args.gleam**: Added `poll_interval` field to `GenerateOptions` and parsing for `--poll-interval` option
- **src/cquill/cli/generate.gleam**: Implemented `watch` function with polling loop, schema fingerprinting, and change detection
- **src/cquill_crypto_ffi.erl**: Added FFI module for SHA-256 hashing via Erlang's crypto module
- **test/cquill/cli/args_test.gleam**: Added 6 new tests for poll-interval parsing
- **docs/reference/config.md**: Added Watch Mode documentation section with examples

## Test plan

- [x] Run `gleam test` - all 1,041 tests pass
- [x] Verify `--poll-interval` parsing with valid values (e.g., `2000`)
- [x] Verify `--poll-interval` rejects invalid values (non-integer, negative, zero)
- [x] Verify default poll interval is 5000ms
- [x] Verify `--watch` flag sets watch mode to true

## Example Usage

```bash
# Basic watch mode (polls every 5 seconds)
cquill generate --database-url $DATABASE_URL --watch

# Watch with custom poll interval (2 seconds)
cquill generate --database-url $DATABASE_URL --watch --poll-interval 2000

# Watch with verbose output
cquill generate --database-url $DATABASE_URL --watch --verbose
```

Expected output:
```
cquill watch mode starting...

Initial generation complete: 5 files generated

Watching for schema changes...
Poll interval: 5000ms
Press Ctrl+C to stop.

[2024-01-15 10:30:25] Schema change detected, regenerating...
  Tables: 6
  Enums: 2
[2024-01-15 10:30:25] Regenerated 6 files
```

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)