### PR TITLE
feat: add ilike() and not_ilike() query builder functions

### DIFF
--- a/src/cquill/query.gleam
+++ b/src/cquill/query.gleam
@@ -261,6 +261,20 @@ pub fn not_like(field: String, pattern: String) -> Condition {
   NotLike(field:, pattern:)
 }
 
+/// Create a case-insensitive LIKE condition: field ILIKE pattern (PostgreSQL)
+/// For case-insensitive pattern matching. The pattern uses SQL wildcards:
+/// - `%` matches any sequence of characters
+/// - `_` matches any single character
+pub fn ilike(field: String, pattern: String) -> Condition {
+  ILike(field:, pattern:)
+}
+
+/// Create a case-insensitive NOT LIKE condition: field NOT ILIKE pattern (PostgreSQL)
+/// Negated case-insensitive pattern matching.
+pub fn not_ilike(field: String, pattern: String) -> Condition {
+  NotILike(field:, pattern:)
+}
+
 /// Create an IS NULL condition
 pub fn is_null(field: String) -> Condition {
   IsNull(field)

--- a/test/cquill/query_test.gleam
+++ b/test/cquill/query_test.gleam
@@ -1,6 +1,7 @@
 import cquill/query.{
-  desc, eq_bool, eq_int, eq_string, gt_int, in_ints, in_strings, is_not_null,
-  is_null, like, lt_int, lte_int, not_eq, nulls_last,
+  desc, eq_bool, eq_int, eq_string, gt_int, ilike, in_ints, in_strings,
+  is_not_null, is_null, like, lt_int, lte_int, not_eq, not_ilike, not_like,
+  nulls_last,
 }
 import cquill/query/ast.{
   Asc, Desc, Eq, IntValue, NullsLast, Query as QueryRecord, SelectAll,
@@ -275,6 +276,30 @@ pub fn like_test() {
   let cond = like("name", "%john%")
   case cond {
     ast.Like("name", "%john%") -> should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+pub fn not_like_test() {
+  let cond = not_like("name", "%admin%")
+  case cond {
+    ast.NotLike("name", "%admin%") -> should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+pub fn ilike_test() {
+  let cond = ilike("email", "%@EXAMPLE.COM")
+  case cond {
+    ast.ILike("email", "%@EXAMPLE.COM") -> should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+pub fn not_ilike_test() {
+  let cond = not_ilike("email", "%@spam.com")
+  case cond {
+    ast.NotILike("email", "%@spam.com") -> should.be_true(True)
     _ -> should.fail()
   }
 }


### PR DESCRIPTION
## Summary

- Add `ilike(field, pattern)` for case-insensitive LIKE pattern matching (PostgreSQL ILIKE)
- Add `not_ilike(field, pattern)` for negated case-insensitive pattern matching
- The AST already supported `ILike`/`NotILike` types but the query builder was missing the corresponding functions

Fixes #115

## Changes

**`src/cquill/query.gleam`**
- Added `ilike()` function that creates `ast.ILike` condition
- Added `not_ilike()` function that creates `ast.NotILike` condition

**`test/cquill/query_test.gleam`**
- Added `ilike_test()` to verify ilike condition creation
- Added `not_ilike_test()` to verify not_ilike condition creation  
- Added `not_like_test()` for completeness (was missing)

## Test plan

- [x] Run `gleam test` - all 1332 tests pass (1 expected postgres failure)
- [x] Verify `ilike()` creates correct AST node
- [x] Verify `not_ilike()` creates correct AST node
- [x] Verify formatting with `gleam format`

## Working Example

```gleam
import cquill/query
import cquill/schema
import cquill/schema/field

pub fn main() {
  let user_schema = schema.new("users")
    |> schema.field(field.integer("id") |> field.primary_key)
    |> schema.field(field.string("email") |> field.not_null)

  // Case-insensitive email search
  let q = query.from(user_schema)
    |> query.where(query.ilike("email", "%@EXAMPLE.COM"))

  // Exclude spam domains (case-insensitive)
  let q2 = query.from(user_schema)
    |> query.where(query.not_ilike("email", "%@spam.%"))
}
```

## New Tests Added

```gleam
pub fn ilike_test() {
  let cond = ilike("email", "%@EXAMPLE.COM")
  case cond {
    ast.ILike("email", "%@EXAMPLE.COM") -> should.be_true(True)
    _ -> should.fail()
  }
}

pub fn not_ilike_test() {
  let cond = not_ilike("email", "%@spam.com")
  case cond {
    ast.NotILike("email", "%@spam.com") -> should.be_true(True)
    _ -> should.fail()
  }
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)