### PR TITLE
feat: implement changeset module for data validation

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -14,6 +14,7 @@ links = [
 gleam_stdlib = ">= 0.44.0 and < 2.0.0"
 gleam_erlang = ">= 1.0.0 and < 2.0.0"
 gleam_otp = ">= 1.0.0 and < 2.0.0"
+gleam_regexp = ">= 1.0.0 and < 2.0.0"
 pog = ">= 4.0.0 and < 5.0.0"
 clip = ">= 1.2.0 and < 2.0.0"
 argv = ">= 1.0.2 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -10,6 +10,7 @@ packages = [
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
   { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
   { name = "gleam_otp", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "BA6A294E295E428EC1562DC1C11EA7530DCB981E8359134BEABC8493B7B2258E" },
+  { name = "gleam_regexp", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "9C215C6CA84A5B35BB934A9B61A9A306EC743153BE2B0425A0D032E477B062A9" },
   { name = "gleam_stdlib", version = "0.68.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "F7FAEBD8EF260664E86A46C8DBA23508D1D11BB3BCC6EE1B89B3BC3E5C83FF1E" },
   { name = "gleam_time", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "0DF3834D20193F0A38D0EB21F0A78D48F2EC276C285969131B86DF8D4EF9E762" },
   { name = "gleescript", version = "1.5.2", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_erlang", "gleam_stdlib", "simplifile", "snag", "tom"], otp_app = "gleescript", source = "hex", outer_checksum = "27AC58481742ED29D9B37C506F78958A8AD798750A79ED08C8F8AFBA8F23563B" },
@@ -29,6 +30,7 @@ clip = { version = ">= 1.2.0 and < 2.0.0" }
 envoy = { version = ">= 1.1.0 and < 2.0.0" }
 gleam_erlang = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_otp = { version = ">= 1.0.0 and < 2.0.0" }
+gleam_regexp = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }
 gleescript = { version = ">= 1.5.2 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }

--- a/src/cquill/changeset.gleam
+++ b/src/cquill/changeset.gleam
@@ -1,0 +1,635 @@
+// cquill Changeset Layer
+//
+// This module provides data validation and transformation before persistence.
+// It is part of the pure core — no I/O, no side effects.
+//
+// ARCHITECTURAL PRINCIPLE: Changesets are pure data transformations.
+// They validate and transform input data, producing either valid output
+// or structured error information.
+//
+// DESIGN PATTERN: Inspired by Ecto's Changeset
+// - Changesets track changes to data
+// - Validations are composable via pipelines
+// - Errors are structured and field-specific
+// - Valid changesets can be applied to get the result
+//
+// Example:
+// ```gleam
+// let result = changeset.new(user_data)
+//   |> changeset.validate_required(["email", "name"])
+//   |> changeset.validate_format("email", "^[^@]+@[^@]+$")
+//   |> changeset.validate_length("name", min: 2, max: 100)
+//   |> changeset.apply()
+//
+// case result {
+//   Ok(valid_data) -> // use valid_data
+//   Error(errors) -> // handle validation errors
+// }
+// ```
+
+import gleam/dict.{type Dict}
+import gleam/dynamic.{type Dynamic}
+import gleam/dynamic/decode
+import gleam/int
+import gleam/list
+import gleam/option.{type Option, None, Some}
+import gleam/regexp
+import gleam/result
+import gleam/string
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+/// A changeset represents a set of changes to be validated and applied.
+/// It tracks the original data, changes, and any validation errors.
+pub type Changeset {
+  Changeset(
+    /// The original data (if updating existing record)
+    data: Option(Dict(String, Dynamic)),
+    /// The changes/new values being applied
+    changes: Dict(String, Dynamic),
+    /// Validation errors by field name
+    errors: Dict(String, List(ValidationError)),
+    /// Whether the changeset is valid (no errors)
+    valid: Bool,
+    /// Fields that were validated
+    validated_fields: List(String),
+  )
+}
+
+/// A validation error for a specific field
+pub type ValidationError {
+  ValidationError(
+    /// The error message
+    message: String,
+    /// The validation type that failed
+    validation: ValidationType,
+  )
+}
+
+/// Types of validations that can fail
+pub type ValidationType {
+  /// Field is required but missing or empty
+  Required
+  /// Field format doesn't match pattern
+  Format
+  /// Field length is invalid
+  Length(constraint: LengthConstraint)
+  /// Field value is not in allowed list
+  Inclusion
+  /// Field value is in excluded list
+  Exclusion
+  /// Numeric value out of range
+  Range
+  /// Custom validation failed
+  Custom(name: String)
+  /// Field must be unique (checked externally)
+  Uniqueness
+  /// Confirmation field doesn't match
+  Confirmation
+  /// Field must be accepted (for terms, etc.)
+  Acceptance
+}
+
+/// Length constraint details
+pub type LengthConstraint {
+  MinLength(min: Int)
+  MaxLength(max: Int)
+  ExactLength(length: Int)
+  RangeLength(min: Int, max: Int)
+}
+
+// ============================================================================
+// CONSTRUCTORS
+// ============================================================================
+
+/// Create a new changeset from input data (for inserts)
+pub fn new(changes: Dict(String, Dynamic)) -> Changeset {
+  Changeset(
+    data: None,
+    changes: changes,
+    errors: dict.new(),
+    valid: True,
+    validated_fields: [],
+  )
+}
+
+/// Create a changeset for updating existing data
+pub fn change(
+  existing: Dict(String, Dynamic),
+  changes: Dict(String, Dynamic),
+) -> Changeset {
+  Changeset(
+    data: Some(existing),
+    changes: changes,
+    errors: dict.new(),
+    valid: True,
+    validated_fields: [],
+  )
+}
+
+/// Create an empty changeset (useful for forms)
+pub fn empty() -> Changeset {
+  Changeset(
+    data: None,
+    changes: dict.new(),
+    errors: dict.new(),
+    valid: True,
+    validated_fields: [],
+  )
+}
+
+// ============================================================================
+// VALIDATION FUNCTIONS
+// ============================================================================
+
+/// Validate that the specified fields are present and non-empty
+pub fn validate_required(
+  changeset: Changeset,
+  fields: List(String),
+) -> Changeset {
+  list.fold(fields, changeset, fn(cs, field) {
+    let value = get_field(cs, field)
+    case is_present(value) {
+      True -> mark_validated(cs, field)
+      False -> add_error(cs, field, "is required", Required)
+    }
+  })
+}
+
+/// Validate that a string field matches a regex pattern
+pub fn validate_format(
+  changeset: Changeset,
+  field: String,
+  pattern: String,
+) -> Changeset {
+  case get_field_string(changeset, field) {
+    None -> mark_validated(changeset, field)
+    Some(value) -> {
+      case regexp.from_string(pattern) {
+        Error(_) -> add_error(changeset, field, "has invalid format", Format)
+        Ok(re) -> {
+          case regexp.check(re, value) {
+            True -> mark_validated(changeset, field)
+            False -> add_error(changeset, field, "has invalid format", Format)
+          }
+        }
+      }
+    }
+  }
+}
+
+/// Validate string length with minimum constraint
+pub fn validate_length_min(
+  changeset: Changeset,
+  field: String,
+  min: Int,
+) -> Changeset {
+  validate_length_impl(changeset, field, Some(min), None, None)
+}
+
+/// Validate string length with maximum constraint
+pub fn validate_length_max(
+  changeset: Changeset,
+  field: String,
+  max: Int,
+) -> Changeset {
+  validate_length_impl(changeset, field, None, Some(max), None)
+}
+
+/// Validate string length with exact length constraint
+pub fn validate_length_exact(
+  changeset: Changeset,
+  field: String,
+  length: Int,
+) -> Changeset {
+  validate_length_impl(changeset, field, None, None, Some(length))
+}
+
+/// Validate string length with min and max constraints
+pub fn validate_length(
+  changeset: Changeset,
+  field: String,
+  min min: Int,
+  max max: Int,
+) -> Changeset {
+  validate_length_impl(changeset, field, Some(min), Some(max), None)
+}
+
+fn validate_length_impl(
+  changeset: Changeset,
+  field: String,
+  min: Option(Int),
+  max: Option(Int),
+  exact: Option(Int),
+) -> Changeset {
+  case get_field_string(changeset, field) {
+    None -> mark_validated(changeset, field)
+    Some(value) -> {
+      let len = string.length(value)
+      case exact {
+        Some(exact_len) if len != exact_len ->
+          add_error(
+            changeset,
+            field,
+            "must be exactly " <> int.to_string(exact_len) <> " characters",
+            Length(ExactLength(exact_len)),
+          )
+        Some(_) -> mark_validated(changeset, field)
+        None -> {
+          case min, max {
+            Some(min_len), Some(max_len) if len < min_len || len > max_len ->
+              add_error(
+                changeset,
+                field,
+                "must be between "
+                  <> int.to_string(min_len)
+                  <> " and "
+                  <> int.to_string(max_len)
+                  <> " characters",
+                Length(RangeLength(min_len, max_len)),
+              )
+            Some(min_len), None if len < min_len ->
+              add_error(
+                changeset,
+                field,
+                "must be at least " <> int.to_string(min_len) <> " characters",
+                Length(MinLength(min_len)),
+              )
+            None, Some(max_len) if len > max_len ->
+              add_error(
+                changeset,
+                field,
+                "must be at most " <> int.to_string(max_len) <> " characters",
+                Length(MaxLength(max_len)),
+              )
+            _, _ -> mark_validated(changeset, field)
+          }
+        }
+      }
+    }
+  }
+}
+
+/// Validate that a field value is in a list of allowed values
+pub fn validate_inclusion(
+  changeset: Changeset,
+  field: String,
+  allowed: List(String),
+) -> Changeset {
+  case get_field_string(changeset, field) {
+    None -> mark_validated(changeset, field)
+    Some(value) -> {
+      case list.contains(allowed, value) {
+        True -> mark_validated(changeset, field)
+        False -> add_error(changeset, field, "is not a valid option", Inclusion)
+      }
+    }
+  }
+}
+
+/// Validate that a field value is NOT in a list of excluded values
+pub fn validate_exclusion(
+  changeset: Changeset,
+  field: String,
+  excluded: List(String),
+) -> Changeset {
+  case get_field_string(changeset, field) {
+    None -> mark_validated(changeset, field)
+    Some(value) -> {
+      case list.contains(excluded, value) {
+        True -> add_error(changeset, field, "is not allowed", Exclusion)
+        False -> mark_validated(changeset, field)
+      }
+    }
+  }
+}
+
+/// Validate that a numeric field is within a range
+pub fn validate_number_range(
+  changeset: Changeset,
+  field: String,
+  min min: Option(Int),
+  max max: Option(Int),
+) -> Changeset {
+  case get_field_int(changeset, field) {
+    None -> mark_validated(changeset, field)
+    Some(value) -> {
+      case min, max {
+        Some(min_val), Some(max_val) if value < min_val || value > max_val ->
+          add_error(
+            changeset,
+            field,
+            "must be between "
+              <> int.to_string(min_val)
+              <> " and "
+              <> int.to_string(max_val),
+            Range,
+          )
+        Some(min_val), None if value < min_val ->
+          add_error(
+            changeset,
+            field,
+            "must be at least " <> int.to_string(min_val),
+            Range,
+          )
+        None, Some(max_val) if value > max_val ->
+          add_error(
+            changeset,
+            field,
+            "must be at most " <> int.to_string(max_val),
+            Range,
+          )
+        _, _ -> mark_validated(changeset, field)
+      }
+    }
+  }
+}
+
+/// Validate that a confirmation field matches the original field
+/// e.g., password and password_confirmation
+pub fn validate_confirmation(
+  changeset: Changeset,
+  field: String,
+  confirmation_field: String,
+) -> Changeset {
+  let original = get_field_string(changeset, field)
+  let confirmation = get_field_string(changeset, confirmation_field)
+
+  case original, confirmation {
+    Some(orig), Some(conf) if orig != conf ->
+      add_error(changeset, confirmation_field, "does not match", Confirmation)
+    _, _ -> mark_validated(changeset, confirmation_field)
+  }
+}
+
+/// Validate that a boolean field is true (for accepting terms, etc.)
+pub fn validate_acceptance(changeset: Changeset, field: String) -> Changeset {
+  case get_field_bool(changeset, field) {
+    Some(True) -> mark_validated(changeset, field)
+    Some(False) -> add_error(changeset, field, "must be accepted", Acceptance)
+    None -> add_error(changeset, field, "must be accepted", Acceptance)
+  }
+}
+
+/// Apply a custom validation function
+/// The function should return Ok(Nil) if valid, or Error(message) if invalid
+pub fn validate_custom(
+  changeset: Changeset,
+  field: String,
+  name: String,
+  validator: fn(Changeset) -> Result(Nil, String),
+) -> Changeset {
+  case validator(changeset) {
+    Ok(_) -> mark_validated(changeset, field)
+    Error(message) -> add_error(changeset, field, message, Custom(name))
+  }
+}
+
+/// Validate a field only if it is present (non-nil)
+/// Useful for optional fields that have constraints when provided
+pub fn validate_if_present(
+  changeset: Changeset,
+  field: String,
+  validator: fn(Changeset) -> Changeset,
+) -> Changeset {
+  case get_field(changeset, field) {
+    None -> changeset
+    Some(_) -> validator(changeset)
+  }
+}
+
+// ============================================================================
+// CHANGE FUNCTIONS
+// ============================================================================
+
+/// Put a change into the changeset
+pub fn put_change(
+  changeset: Changeset,
+  field: String,
+  value: Dynamic,
+) -> Changeset {
+  Changeset(..changeset, changes: dict.insert(changeset.changes, field, value))
+}
+
+/// Delete a change from the changeset
+pub fn delete_change(changeset: Changeset, field: String) -> Changeset {
+  Changeset(..changeset, changes: dict.delete(changeset.changes, field))
+}
+
+/// Get a change value from the changeset
+pub fn get_change(changeset: Changeset, field: String) -> Option(Dynamic) {
+  dict.get(changeset.changes, field)
+  |> option.from_result
+}
+
+/// Force a change even if validation would fail
+/// Use with caution — this bypasses validation for the field
+pub fn force_change(
+  changeset: Changeset,
+  field: String,
+  value: Dynamic,
+) -> Changeset {
+  changeset
+  |> put_change(field, value)
+  |> clear_errors(field)
+}
+
+// ============================================================================
+// ERROR FUNCTIONS
+// ============================================================================
+
+/// Add an error to the changeset
+pub fn add_error(
+  changeset: Changeset,
+  field: String,
+  message: String,
+  validation: ValidationType,
+) -> Changeset {
+  let error = ValidationError(message:, validation:)
+  let existing_errors =
+    dict.get(changeset.errors, field)
+    |> result.unwrap([])
+  let updated_errors =
+    dict.insert(changeset.errors, field, [error, ..existing_errors])
+  Changeset(..changeset, errors: updated_errors, valid: False)
+}
+
+/// Clear all errors for a specific field
+pub fn clear_errors(changeset: Changeset, field: String) -> Changeset {
+  let updated_errors = dict.delete(changeset.errors, field)
+  let is_valid = dict.is_empty(updated_errors)
+  Changeset(..changeset, errors: updated_errors, valid: is_valid)
+}
+
+/// Clear all errors from the changeset
+pub fn clear_all_errors(changeset: Changeset) -> Changeset {
+  Changeset(..changeset, errors: dict.new(), valid: True)
+}
+
+/// Get errors for a specific field
+pub fn get_errors(changeset: Changeset, field: String) -> List(ValidationError) {
+  dict.get(changeset.errors, field)
+  |> result.unwrap([])
+}
+
+/// Get all errors as a list of (field, error) tuples
+pub fn all_errors(changeset: Changeset) -> List(#(String, ValidationError)) {
+  dict.to_list(changeset.errors)
+  |> list.flat_map(fn(pair) {
+    let #(field, errors) = pair
+    list.map(errors, fn(err) { #(field, err) })
+  })
+}
+
+/// Check if a specific field has errors
+pub fn has_error(changeset: Changeset, field: String) -> Bool {
+  case dict.get(changeset.errors, field) {
+    Ok(errors) -> !list.is_empty(errors)
+    Error(_) -> False
+  }
+}
+
+// ============================================================================
+// RESULT FUNCTIONS
+// ============================================================================
+
+/// Apply the changeset and return the result
+/// Returns Ok(changes) if valid, Error(errors) if invalid
+pub fn apply(
+  changeset: Changeset,
+) -> Result(Dict(String, Dynamic), Dict(String, List(ValidationError))) {
+  case changeset.valid {
+    True -> Ok(changeset.changes)
+    False -> Error(changeset.errors)
+  }
+}
+
+/// Check if the changeset is valid
+pub fn is_valid(changeset: Changeset) -> Bool {
+  changeset.valid
+}
+
+/// Get the changes from the changeset (regardless of validity)
+pub fn get_changes(changeset: Changeset) -> Dict(String, Dynamic) {
+  changeset.changes
+}
+
+/// Get the original data (if this is an update changeset)
+pub fn get_data(changeset: Changeset) -> Option(Dict(String, Dynamic)) {
+  changeset.data
+}
+
+/// Merge changes from the changeset with the original data
+/// For updates, this combines old data with new changes
+pub fn merge_changes(changeset: Changeset) -> Dict(String, Dynamic) {
+  case changeset.data {
+    None -> changeset.changes
+    Some(data) -> dict.merge(data, changeset.changes)
+  }
+}
+
+// ============================================================================
+// HELPER FUNCTIONS
+// ============================================================================
+
+/// Get a field value from changes or original data
+fn get_field(changeset: Changeset, field: String) -> Option(Dynamic) {
+  case dict.get(changeset.changes, field) {
+    Ok(value) -> Some(value)
+    Error(_) -> {
+      case changeset.data {
+        None -> None
+        Some(data) ->
+          dict.get(data, field)
+          |> option.from_result
+      }
+    }
+  }
+}
+
+/// Get a field value as a string
+fn get_field_string(changeset: Changeset, field: String) -> Option(String) {
+  case get_field(changeset, field) {
+    None -> None
+    Some(value) -> {
+      case decode.run(value, decode.string) {
+        Ok(s) -> Some(s)
+        Error(_) -> None
+      }
+    }
+  }
+}
+
+/// Get a field value as an int
+fn get_field_int(changeset: Changeset, field: String) -> Option(Int) {
+  case get_field(changeset, field) {
+    None -> None
+    Some(value) -> {
+      case decode.run(value, decode.int) {
+        Ok(i) -> Some(i)
+        Error(_) -> None
+      }
+    }
+  }
+}
+
+/// Get a field value as a bool
+fn get_field_bool(changeset: Changeset, field: String) -> Option(Bool) {
+  case get_field(changeset, field) {
+    None -> None
+    Some(value) -> {
+      case decode.run(value, decode.bool) {
+        Ok(b) -> Some(b)
+        Error(_) -> None
+      }
+    }
+  }
+}
+
+/// Check if a value is present (not None and not empty string)
+fn is_present(value: Option(Dynamic)) -> Bool {
+  case value {
+    None -> False
+    Some(v) -> {
+      case decode.run(v, decode.string) {
+        Ok(s) -> !string.is_empty(s)
+        Error(_) -> True
+      }
+    }
+  }
+}
+
+/// Mark a field as validated
+fn mark_validated(changeset: Changeset, field: String) -> Changeset {
+  case list.contains(changeset.validated_fields, field) {
+    True -> changeset
+    False ->
+      Changeset(..changeset, validated_fields: [
+        field,
+        ..changeset.validated_fields
+      ])
+  }
+}
+
+// ============================================================================
+// FORMATTING
+// ============================================================================
+
+/// Format all errors as a human-readable string
+pub fn format_errors(changeset: Changeset) -> String {
+  all_errors(changeset)
+  |> list.map(fn(pair) {
+    let #(field, error) = pair
+    field <> " " <> error.message
+  })
+  |> string.join(", ")
+}
+
+/// Format errors for a specific field
+pub fn format_field_errors(changeset: Changeset, field: String) -> String {
+  get_errors(changeset, field)
+  |> list.map(fn(error) { error.message })
+  |> string.join(", ")
+}

--- a/test/cquill/changeset_test.gleam
+++ b/test/cquill/changeset_test.gleam
@@ -1,0 +1,743 @@
+import cquill/changeset.{
+  Acceptance, Confirmation, Custom, ExactLength, Exclusion, Format, Inclusion,
+  Length, MaxLength, MinLength, Range, RangeLength, Required, ValidationError,
+}
+import gleam/dict
+import gleam/dynamic
+import gleam/list
+import gleam/option.{None, Some}
+import gleam/string
+import gleeunit
+import gleeunit/should
+
+pub fn main() {
+  gleeunit.main()
+}
+
+// ============================================================================
+// CONSTRUCTOR TESTS
+// ============================================================================
+
+pub fn new_creates_valid_changeset_test() {
+  let changes =
+    dict.new()
+    |> dict.insert("email", dynamic.string("test@example.com"))
+
+  let cs = changeset.new(changes)
+
+  changeset.is_valid(cs) |> should.be_true
+  changeset.get_data(cs) |> should.equal(None)
+}
+
+pub fn change_creates_changeset_with_existing_data_test() {
+  let existing =
+    dict.new()
+    |> dict.insert("id", dynamic.int(1))
+    |> dict.insert("email", dynamic.string("old@example.com"))
+
+  let changes =
+    dict.new()
+    |> dict.insert("email", dynamic.string("new@example.com"))
+
+  let cs = changeset.change(existing, changes)
+
+  changeset.is_valid(cs) |> should.be_true
+  changeset.get_data(cs) |> should.equal(Some(existing))
+  changeset.get_changes(cs) |> should.equal(changes)
+}
+
+pub fn empty_creates_empty_changeset_test() {
+  let cs = changeset.empty()
+
+  changeset.is_valid(cs) |> should.be_true
+  changeset.get_changes(cs) |> dict.size |> should.equal(0)
+}
+
+// ============================================================================
+// VALIDATE_REQUIRED TESTS
+// ============================================================================
+
+pub fn validate_required_passes_for_present_field_test() {
+  let changes =
+    dict.new()
+    |> dict.insert("email", dynamic.string("test@example.com"))
+
+  let cs =
+    changeset.new(changes)
+    |> changeset.validate_required(["email"])
+
+  changeset.is_valid(cs) |> should.be_true
+}
+
+pub fn validate_required_fails_for_missing_field_test() {
+  let changes = dict.new()
+
+  let cs =
+    changeset.new(changes)
+    |> changeset.validate_required(["email"])
+
+  changeset.is_valid(cs) |> should.be_false
+  changeset.has_error(cs, "email") |> should.be_true
+
+  let errors = changeset.get_errors(cs, "email")
+  errors |> should.not_equal([])
+
+  case errors {
+    [ValidationError(message: msg, validation: Required)] -> {
+      msg |> should.equal("is required")
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn validate_required_fails_for_empty_string_test() {
+  let changes =
+    dict.new()
+    |> dict.insert("email", dynamic.string(""))
+
+  let cs =
+    changeset.new(changes)
+    |> changeset.validate_required(["email"])
+
+  changeset.is_valid(cs) |> should.be_false
+  changeset.has_error(cs, "email") |> should.be_true
+}
+
+pub fn validate_required_multiple_fields_test() {
+  let changes =
+    dict.new()
+    |> dict.insert("email", dynamic.string("test@example.com"))
+
+  let cs =
+    changeset.new(changes)
+    |> changeset.validate_required(["email", "name"])
+
+  changeset.is_valid(cs) |> should.be_false
+  changeset.has_error(cs, "email") |> should.be_false
+  changeset.has_error(cs, "name") |> should.be_true
+}
+
+// ============================================================================
+// VALIDATE_FORMAT TESTS
+// ============================================================================
+
+pub fn validate_format_passes_for_matching_pattern_test() {
+  let changes =
+    dict.new()
+    |> dict.insert("email", dynamic.string("test@example.com"))
+
+  let cs =
+    changeset.new(changes)
+    |> changeset.validate_format("email", "^[^@]+@[^@]+$")
+
+  changeset.is_valid(cs) |> should.be_true
+}
+
+pub fn validate_format_fails_for_non_matching_pattern_test() {
+  let changes =
+    dict.new()
+    |> dict.insert("email", dynamic.string("invalid-email"))
+
+  let cs =
+    changeset.new(changes)
+    |> changeset.validate_format("email", "^[^@]+@[^@]+$")
+
+  changeset.is_valid(cs) |> should.be_false
+  changeset.has_error(cs, "email") |> should.be_true
+
+  let errors = changeset.get_errors(cs, "email")
+  case errors {
+    [ValidationError(message: _, validation: Format)] -> should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+pub fn validate_format_skips_missing_field_test() {
+  let changes = dict.new()
+
+  let cs =
+    changeset.new(changes)
+    |> changeset.validate_format("email", "^[^@]+@[^@]+$")
+
+  changeset.is_valid(cs) |> should.be_true
+}
+
+// ============================================================================
+// VALIDATE_LENGTH TESTS
+// ============================================================================
+
+pub fn validate_length_min_passes_test() {
+  let changes =
+    dict.new()
+    |> dict.insert("name", dynamic.string("John"))
+
+  let cs =
+    changeset.new(changes)
+    |> changeset.validate_length_min("name", 2)
+
+  changeset.is_valid(cs) |> should.be_true
+}
+
+pub fn validate_length_min_fails_test() {
+  let changes =
+    dict.new()
+    |> dict.insert("name", dynamic.string("J"))
+
+  let cs =
+    changeset.new(changes)
+    |> changeset.validate_length_min("name", 2)
+
+  changeset.is_valid(cs) |> should.be_false
+  changeset.has_error(cs, "name") |> should.be_true
+
+  let errors = changeset.get_errors(cs, "name")
+  case errors {
+    [ValidationError(message: _, validation: Length(MinLength(2)))] ->
+      should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+pub fn validate_length_max_passes_test() {
+  let changes =
+    dict.new()
+    |> dict.insert("name", dynamic.string("John"))
+
+  let cs =
+    changeset.new(changes)
+    |> changeset.validate_length_max("name", 10)
+
+  changeset.is_valid(cs) |> should.be_true
+}
+
+pub fn validate_length_max_fails_test() {
+  let changes =
+    dict.new()
+    |> dict.insert("name", dynamic.string("This is a very long name"))
+
+  let cs =
+    changeset.new(changes)
+    |> changeset.validate_length_max("name", 10)
+
+  changeset.is_valid(cs) |> should.be_false
+
+  let errors = changeset.get_errors(cs, "name")
+  case errors {
+    [ValidationError(message: _, validation: Length(MaxLength(10)))] ->
+      should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+pub fn validate_length_exact_passes_test() {
+  let changes =
+    dict.new()
+    |> dict.insert("code", dynamic.string("ABC123"))
+
+  let cs =
+    changeset.new(changes)
+    |> changeset.validate_length_exact("code", 6)
+
+  changeset.is_valid(cs) |> should.be_true
+}
+
+pub fn validate_length_exact_fails_test() {
+  let changes =
+    dict.new()
+    |> dict.insert("code", dynamic.string("ABC12"))
+
+  let cs =
+    changeset.new(changes)
+    |> changeset.validate_length_exact("code", 6)
+
+  changeset.is_valid(cs) |> should.be_false
+
+  let errors = changeset.get_errors(cs, "code")
+  case errors {
+    [ValidationError(message: _, validation: Length(ExactLength(6)))] ->
+      should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+pub fn validate_length_range_passes_test() {
+  let changes =
+    dict.new()
+    |> dict.insert("name", dynamic.string("John"))
+
+  let cs =
+    changeset.new(changes)
+    |> changeset.validate_length("name", min: 2, max: 100)
+
+  changeset.is_valid(cs) |> should.be_true
+}
+
+pub fn validate_length_range_fails_below_min_test() {
+  let changes =
+    dict.new()
+    |> dict.insert("name", dynamic.string("J"))
+
+  let cs =
+    changeset.new(changes)
+    |> changeset.validate_length("name", min: 2, max: 100)
+
+  changeset.is_valid(cs) |> should.be_false
+
+  let errors = changeset.get_errors(cs, "name")
+  case errors {
+    [ValidationError(message: _, validation: Length(RangeLength(2, 100)))] ->
+      should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+// ============================================================================
+// VALIDATE_INCLUSION TESTS
+// ============================================================================
+
+pub fn validate_inclusion_passes_for_allowed_value_test() {
+  let changes =
+    dict.new()
+    |> dict.insert("role", dynamic.string("admin"))
+
+  let cs =
+    changeset.new(changes)
+    |> changeset.validate_inclusion("role", ["admin", "user", "guest"])
+
+  changeset.is_valid(cs) |> should.be_true
+}
+
+pub fn validate_inclusion_fails_for_disallowed_value_test() {
+  let changes =
+    dict.new()
+    |> dict.insert("role", dynamic.string("superadmin"))
+
+  let cs =
+    changeset.new(changes)
+    |> changeset.validate_inclusion("role", ["admin", "user", "guest"])
+
+  changeset.is_valid(cs) |> should.be_false
+
+  let errors = changeset.get_errors(cs, "role")
+  case errors {
+    [ValidationError(message: _, validation: Inclusion)] -> should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+// ============================================================================
+// VALIDATE_EXCLUSION TESTS
+// ============================================================================
+
+pub fn validate_exclusion_passes_for_allowed_value_test() {
+  let changes =
+    dict.new()
+    |> dict.insert("username", dynamic.string("john"))
+
+  let cs =
+    changeset.new(changes)
+    |> changeset.validate_exclusion("username", ["admin", "root", "system"])
+
+  changeset.is_valid(cs) |> should.be_true
+}
+
+pub fn validate_exclusion_fails_for_excluded_value_test() {
+  let changes =
+    dict.new()
+    |> dict.insert("username", dynamic.string("admin"))
+
+  let cs =
+    changeset.new(changes)
+    |> changeset.validate_exclusion("username", ["admin", "root", "system"])
+
+  changeset.is_valid(cs) |> should.be_false
+
+  let errors = changeset.get_errors(cs, "username")
+  case errors {
+    [ValidationError(message: _, validation: Exclusion)] -> should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+// ============================================================================
+// VALIDATE_NUMBER_RANGE TESTS
+// ============================================================================
+
+pub fn validate_number_range_passes_test() {
+  let changes =
+    dict.new()
+    |> dict.insert("age", dynamic.int(25))
+
+  let cs =
+    changeset.new(changes)
+    |> changeset.validate_number_range("age", min: Some(18), max: Some(120))
+
+  changeset.is_valid(cs) |> should.be_true
+}
+
+pub fn validate_number_range_fails_below_min_test() {
+  let changes =
+    dict.new()
+    |> dict.insert("age", dynamic.int(15))
+
+  let cs =
+    changeset.new(changes)
+    |> changeset.validate_number_range("age", min: Some(18), max: Some(120))
+
+  changeset.is_valid(cs) |> should.be_false
+
+  let errors = changeset.get_errors(cs, "age")
+  case errors {
+    [ValidationError(message: _, validation: Range)] -> should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+pub fn validate_number_range_fails_above_max_test() {
+  let changes =
+    dict.new()
+    |> dict.insert("age", dynamic.int(150))
+
+  let cs =
+    changeset.new(changes)
+    |> changeset.validate_number_range("age", min: Some(18), max: Some(120))
+
+  changeset.is_valid(cs) |> should.be_false
+}
+
+// ============================================================================
+// VALIDATE_CONFIRMATION TESTS
+// ============================================================================
+
+pub fn validate_confirmation_passes_test() {
+  let changes =
+    dict.new()
+    |> dict.insert("password", dynamic.string("secret123"))
+    |> dict.insert("password_confirmation", dynamic.string("secret123"))
+
+  let cs =
+    changeset.new(changes)
+    |> changeset.validate_confirmation("password", "password_confirmation")
+
+  changeset.is_valid(cs) |> should.be_true
+}
+
+pub fn validate_confirmation_fails_test() {
+  let changes =
+    dict.new()
+    |> dict.insert("password", dynamic.string("secret123"))
+    |> dict.insert("password_confirmation", dynamic.string("different"))
+
+  let cs =
+    changeset.new(changes)
+    |> changeset.validate_confirmation("password", "password_confirmation")
+
+  changeset.is_valid(cs) |> should.be_false
+  changeset.has_error(cs, "password_confirmation") |> should.be_true
+
+  let errors = changeset.get_errors(cs, "password_confirmation")
+  case errors {
+    [ValidationError(message: _, validation: Confirmation)] ->
+      should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+// ============================================================================
+// VALIDATE_ACCEPTANCE TESTS
+// ============================================================================
+
+pub fn validate_acceptance_passes_test() {
+  let changes =
+    dict.new()
+    |> dict.insert("terms", dynamic.bool(True))
+
+  let cs =
+    changeset.new(changes)
+    |> changeset.validate_acceptance("terms")
+
+  changeset.is_valid(cs) |> should.be_true
+}
+
+pub fn validate_acceptance_fails_for_false_test() {
+  let changes =
+    dict.new()
+    |> dict.insert("terms", dynamic.bool(False))
+
+  let cs =
+    changeset.new(changes)
+    |> changeset.validate_acceptance("terms")
+
+  changeset.is_valid(cs) |> should.be_false
+
+  let errors = changeset.get_errors(cs, "terms")
+  case errors {
+    [ValidationError(message: _, validation: Acceptance)] ->
+      should.be_true(True)
+    _ -> should.fail()
+  }
+}
+
+pub fn validate_acceptance_fails_for_missing_test() {
+  let changes = dict.new()
+
+  let cs =
+    changeset.new(changes)
+    |> changeset.validate_acceptance("terms")
+
+  changeset.is_valid(cs) |> should.be_false
+}
+
+// ============================================================================
+// VALIDATE_CUSTOM TESTS
+// ============================================================================
+
+pub fn validate_custom_passes_test() {
+  let changes =
+    dict.new()
+    |> dict.insert("value", dynamic.int(10))
+
+  let validator = fn(_cs) { Ok(Nil) }
+
+  let cs =
+    changeset.new(changes)
+    |> changeset.validate_custom("value", "always_valid", validator)
+
+  changeset.is_valid(cs) |> should.be_true
+}
+
+pub fn validate_custom_fails_test() {
+  let changes =
+    dict.new()
+    |> dict.insert("value", dynamic.int(10))
+
+  let validator = fn(_cs) { Error("custom validation failed") }
+
+  let cs =
+    changeset.new(changes)
+    |> changeset.validate_custom("value", "custom_check", validator)
+
+  changeset.is_valid(cs) |> should.be_false
+
+  let errors = changeset.get_errors(cs, "value")
+  case errors {
+    [ValidationError(message: msg, validation: Custom("custom_check"))] -> {
+      msg |> should.equal("custom validation failed")
+    }
+    _ -> should.fail()
+  }
+}
+
+// ============================================================================
+// VALIDATE_IF_PRESENT TESTS
+// ============================================================================
+
+pub fn validate_if_present_runs_when_present_test() {
+  let changes =
+    dict.new()
+    |> dict.insert("nickname", dynamic.string("AB"))
+
+  let cs =
+    changeset.new(changes)
+    |> changeset.validate_if_present("nickname", fn(cs) {
+      changeset.validate_length_min(cs, "nickname", 3)
+    })
+
+  changeset.is_valid(cs) |> should.be_false
+}
+
+pub fn validate_if_present_skips_when_missing_test() {
+  let changes = dict.new()
+
+  let cs =
+    changeset.new(changes)
+    |> changeset.validate_if_present("nickname", fn(cs) {
+      changeset.validate_length_min(cs, "nickname", 3)
+    })
+
+  changeset.is_valid(cs) |> should.be_true
+}
+
+// ============================================================================
+// CHANGE FUNCTIONS TESTS
+// ============================================================================
+
+pub fn put_change_adds_change_test() {
+  let cs =
+    changeset.empty()
+    |> changeset.put_change("email", dynamic.string("test@example.com"))
+
+  changeset.get_change(cs, "email")
+  |> should.equal(Some(dynamic.string("test@example.com")))
+}
+
+pub fn delete_change_removes_change_test() {
+  let changes =
+    dict.new()
+    |> dict.insert("email", dynamic.string("test@example.com"))
+
+  let cs =
+    changeset.new(changes)
+    |> changeset.delete_change("email")
+
+  changeset.get_change(cs, "email") |> should.equal(None)
+}
+
+pub fn force_change_adds_and_clears_errors_test() {
+  let changes =
+    dict.new()
+    |> dict.insert("email", dynamic.string("invalid"))
+
+  let cs =
+    changeset.new(changes)
+    |> changeset.validate_format("email", "^[^@]+@[^@]+$")
+
+  changeset.is_valid(cs) |> should.be_false
+
+  let cs2 =
+    cs
+    |> changeset.force_change("email", dynamic.string("valid@example.com"))
+
+  changeset.is_valid(cs2) |> should.be_true
+  changeset.has_error(cs2, "email") |> should.be_false
+}
+
+// ============================================================================
+// APPLY TESTS
+// ============================================================================
+
+pub fn apply_returns_ok_for_valid_changeset_test() {
+  let changes =
+    dict.new()
+    |> dict.insert("email", dynamic.string("test@example.com"))
+
+  let result =
+    changeset.new(changes)
+    |> changeset.validate_required(["email"])
+    |> changeset.apply()
+
+  case result {
+    Ok(data) -> dict.size(data) |> should.equal(1)
+    Error(_) -> should.fail()
+  }
+}
+
+pub fn apply_returns_error_for_invalid_changeset_test() {
+  let changes = dict.new()
+
+  let result =
+    changeset.new(changes)
+    |> changeset.validate_required(["email"])
+    |> changeset.apply()
+
+  case result {
+    Ok(_) -> should.fail()
+    Error(errors) -> dict.has_key(errors, "email") |> should.be_true
+  }
+}
+
+// ============================================================================
+// MERGE_CHANGES TESTS
+// ============================================================================
+
+pub fn merge_changes_combines_data_and_changes_test() {
+  let existing =
+    dict.new()
+    |> dict.insert("id", dynamic.int(1))
+    |> dict.insert("email", dynamic.string("old@example.com"))
+
+  let changes =
+    dict.new()
+    |> dict.insert("email", dynamic.string("new@example.com"))
+
+  let cs = changeset.change(existing, changes)
+  let merged = changeset.merge_changes(cs)
+
+  dict.size(merged) |> should.equal(2)
+}
+
+// ============================================================================
+// ERROR FORMATTING TESTS
+// ============================================================================
+
+pub fn format_errors_returns_readable_string_test() {
+  let changes = dict.new()
+
+  let cs =
+    changeset.new(changes)
+    |> changeset.validate_required(["email", "name"])
+
+  let formatted = changeset.format_errors(cs)
+
+  formatted |> string.contains("email is required") |> should.be_true
+  formatted |> string.contains("name is required") |> should.be_true
+}
+
+pub fn format_field_errors_returns_field_errors_test() {
+  let changes = dict.new()
+
+  let cs =
+    changeset.new(changes)
+    |> changeset.validate_required(["email"])
+
+  let formatted = changeset.format_field_errors(cs, "email")
+
+  formatted |> should.equal("is required")
+}
+
+// ============================================================================
+// PIPELINE TESTS
+// ============================================================================
+
+pub fn full_validation_pipeline_test() {
+  let changes =
+    dict.new()
+    |> dict.insert("email", dynamic.string("test@example.com"))
+    |> dict.insert("name", dynamic.string("John Doe"))
+    |> dict.insert("age", dynamic.int(25))
+    |> dict.insert("role", dynamic.string("user"))
+    |> dict.insert("terms", dynamic.bool(True))
+
+  let result =
+    changeset.new(changes)
+    |> changeset.validate_required(["email", "name"])
+    |> changeset.validate_format("email", "^[^@]+@[^@]+$")
+    |> changeset.validate_length("name", min: 2, max: 100)
+    |> changeset.validate_number_range("age", min: Some(18), max: Some(120))
+    |> changeset.validate_inclusion("role", ["admin", "user", "guest"])
+    |> changeset.validate_acceptance("terms")
+    |> changeset.apply()
+
+  case result {
+    Ok(_) -> should.be_true(True)
+    Error(_) -> should.fail()
+  }
+}
+
+pub fn full_validation_pipeline_with_errors_test() {
+  let changes =
+    dict.new()
+    |> dict.insert("email", dynamic.string("invalid-email"))
+    |> dict.insert("name", dynamic.string("J"))
+    |> dict.insert("age", dynamic.int(15))
+    |> dict.insert("role", dynamic.string("superadmin"))
+    |> dict.insert("terms", dynamic.bool(False))
+
+  let cs =
+    changeset.new(changes)
+    |> changeset.validate_required(["email", "name"])
+    |> changeset.validate_format("email", "^[^@]+@[^@]+$")
+    |> changeset.validate_length("name", min: 2, max: 100)
+    |> changeset.validate_number_range("age", min: Some(18), max: Some(120))
+    |> changeset.validate_inclusion("role", ["admin", "user", "guest"])
+    |> changeset.validate_acceptance("terms")
+
+  changeset.is_valid(cs) |> should.be_false
+  changeset.has_error(cs, "email") |> should.be_true
+  changeset.has_error(cs, "name") |> should.be_true
+  changeset.has_error(cs, "age") |> should.be_true
+  changeset.has_error(cs, "role") |> should.be_true
+  changeset.has_error(cs, "terms") |> should.be_true
+
+  changeset.all_errors(cs) |> list.length |> should.equal(5)
+}


### PR DESCRIPTION
## Summary

Implements the changeset module that was documented in README and CLAUDE.md but did not exist. The changeset provides pure functional data validation and transformation before persistence, following Ecto's design patterns.

Fixes #116

## Features

**Core Types:**
- `Changeset` - tracks original data, changes, validation errors, and validity state
- `ValidationError` - structured error with message and validation type
- `ValidationType` - enum of validation types (Required, Format, Length, etc.)

**Validation Functions:**
- `validate_required(fields)` - ensure fields are present and non-empty
- `validate_format(field, pattern)` - regex pattern matching
- `validate_length(field, min, max)` - string length constraints
- `validate_length_min/max/exact` - individual length constraints
- `validate_inclusion(field, allowed)` - value must be in list
- `validate_exclusion(field, excluded)` - value must NOT be in list
- `validate_number_range(field, min, max)` - numeric bounds
- `validate_confirmation(field, confirmation_field)` - fields must match
- `validate_acceptance(field)` - boolean must be true
- `validate_custom(field, name, validator)` - custom validation function
- `validate_if_present(field, validator)` - conditional validation

**Change Management:**
- `new(changes)` - create changeset for inserts
- `change(existing, changes)` - create changeset for updates
- `put_change/delete_change/get_change` - modify changes
- `force_change` - bypass validation for a field
- `apply()` - get Result with changes or errors
- `merge_changes()` - combine original data with changes

**Error Handling:**
- `add_error/clear_errors/clear_all_errors` - error management
- `get_errors(field)` - get errors for a field
- `all_errors()` - get all errors as list
- `has_error(field)` - check if field has errors
- `format_errors()` - human-readable error string
- `format_field_errors(field)` - errors for specific field

## Changes

**New Files:**
- `src/cquill/changeset.gleam` - main changeset module (~640 lines)
- `test/cquill/changeset_test.gleam` - comprehensive tests (~745 lines)

**Modified Files:**
- `gleam.toml` - added `gleam_regexp` dependency for pattern validation
- `manifest.toml` - updated with new dependency

## Test plan

- [x] Run `gleam test` - 1376 tests pass (44 new changeset tests)
- [x] Verify all validation functions work correctly
- [x] Verify error handling and formatting
- [x] Verify pipeline composition
- [x] Format with `gleam format`

## Working Examples

### Basic Validation Pipeline
```gleam
import cquill/changeset
import gleam/dict
import gleam/dynamic
import gleam/option.{Some}

pub fn validate_user() {
  let user_data = dict.new()
    |> dict.insert("email", dynamic.string("test@example.com"))
    |> dict.insert("name", dynamic.string("John Doe"))
    |> dict.insert("age", dynamic.int(25))
    |> dict.insert("role", dynamic.string("user"))
    |> dict.insert("terms", dynamic.bool(True))

  let result = changeset.new(user_data)
    |> changeset.validate_required(["email", "name"])
    |> changeset.validate_format("email", "^[^@]+@[^@]+$")
    |> changeset.validate_length("name", min: 2, max: 100)
    |> changeset.validate_number_range("age", min: Some(18), max: Some(120))
    |> changeset.validate_inclusion("role", ["admin", "user", "guest"])
    |> changeset.validate_acceptance("terms")
    |> changeset.apply()

  case result {
    Ok(valid_data) -> // Use valid_data for persistence
    Error(errors) -> // Handle validation errors
  }
}
```

### Update Workflow
```gleam
pub fn update_user(existing_user, changes) {
  changeset.change(existing_user, changes)
    |> changeset.validate_format("email", "^[^@]+@[^@]+$")
    |> changeset.validate_if_present("name", fn(cs) {
      changeset.validate_length_min(cs, "name", 2)
    })
    |> changeset.apply()
}
```

### Password Confirmation
```gleam
pub fn validate_password_change(data) {
  changeset.new(data)
    |> changeset.validate_required(["password", "password_confirmation"])
    |> changeset.validate_length_min("password", 8)
    |> changeset.validate_confirmation("password", "password_confirmation")
    |> changeset.apply()
}
```

### Error Handling
```gleam
pub fn handle_errors(changeset) {
  case changeset.is_valid(changeset) {
    True -> Ok(changeset.get_changes(changeset))
    False -> {
      // Get formatted error string
      let error_msg = changeset.format_errors(changeset)
      
      // Or handle field-specific errors
      case changeset.has_error(changeset, "email") {
        True -> {
          let email_errors = changeset.format_field_errors(changeset, "email")
          Error("Email: " <> email_errors)
        }
        False -> Error(error_msg)
      }
    }
  }
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)