### PR TITLE
feat: add in_list and not_in_list as aliases for better API discoverability

### DIFF
--- a/src/cquill/query.gleam
+++ b/src/cquill/query.gleam
@@ -246,9 +246,20 @@ pub fn is_in(field: String, values: List(a)) -> Condition {
   In(field:, values: list.map(values, to_value))
 }
 
+/// Alias for is_in - check if field value is in a list of values
+/// This name may be more discoverable for users expecting `in_list`
+pub fn in_list(field: String, values: List(a)) -> Condition {
+  is_in(field, values)
+}
+
 /// Create a NOT IN condition: field NOT IN (values...)
 pub fn is_not_in(field: String, values: List(a)) -> Condition {
   NotIn(field:, values: list.map(values, to_value))
+}
+
+/// Alias for is_not_in - check if field value is NOT in a list of values
+pub fn not_in_list(field: String, values: List(a)) -> Condition {
+  is_not_in(field, values)
 }
 
 /// Create a LIKE condition: field LIKE pattern

--- a/test/cquill/query_test.gleam
+++ b/test/cquill/query_test.gleam
@@ -1,7 +1,7 @@
 import cquill/query.{
-  desc, eq_bool, eq_int, eq_string, gt_int, ilike, in_ints, in_strings,
-  is_not_null, is_null, like, lt_int, lte_int, not_eq, not_ilike, not_like,
-  nulls_last,
+  desc, eq_bool, eq_int, eq_string, gt_int, ilike, in_ints, in_list, in_strings,
+  is_not_null, is_null, like, lt_int, lte_int, not_eq, not_ilike, not_in_list,
+  not_like, nulls_last,
 }
 import cquill/query/ast.{
   Asc, Desc, Eq, IntValue, NullsLast, Query as QueryRecord, SelectAll,
@@ -264,6 +264,32 @@ pub fn in_strings_test() {
   let cond = in_strings("status", ["pending", "approved"])
   case cond {
     ast.In("status", values) -> {
+      values
+      |> list.length
+      |> should.equal(2)
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn in_list_test() {
+  // in_list is an alias for is_in - verify it produces the same AST
+  let cond = in_list("category", ["electronics", "books", "toys"])
+  case cond {
+    ast.In("category", values) -> {
+      values
+      |> list.length
+      |> should.equal(3)
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn not_in_list_test() {
+  // not_in_list is an alias for is_not_in - verify it produces the same AST
+  let cond = not_in_list("status", ["deleted", "archived"])
+  case cond {
+    ast.NotIn("status", values) -> {
       values
       |> list.length
       |> should.equal(2)


### PR DESCRIPTION
## Summary
- Adds `in_list()` as an alias for `is_in()` for better API discoverability
- Adds `not_in_list()` as an alias for `is_not_in()` for consistency
- Both original functions remain available - aliases delegate to them

Closes #118

## Working Example

```gleam
import cquill/query
import cquill/schema
import cquill/schema/field

// Both naming conventions now work:

// Original API
let original_query = query.from(user_schema)
  |> query.where(query.is_in("status", ["active", "pending"]))

// New alias (same behavior)
let alias_query = query.from(user_schema)
  |> query.where(query.in_list("status", ["active", "pending"]))

// Both produce identical results:
// ast.In("status", [Value("active"), Value("pending")])
```

## Test plan
- [x] Added `in_list_test` - verifies alias produces correct In AST
- [x] Added `not_in_list_test` - verifies alias produces correct NotIn AST
- [x] All 1383 tests pass (postgres integration test skipped - no local DB)
- [x] Code formatted with `gleam format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)