### PR TITLE
feat: add field.text() type for schema definitions

### DIFF
--- a/src/cquill/schema/field.gleam
+++ b/src/cquill/schema/field.gleam
@@ -35,9 +35,14 @@ pub type FieldType {
   /// SQL: DECIMAL, NUMERIC
   Decimal(precision: Int, scale: Int)
 
-  /// Variable-length string
-  /// SQL: VARCHAR, TEXT, CHARACTER VARYING
+  /// Variable-length string with optional length limit
+  /// SQL: VARCHAR, CHARACTER VARYING
   String
+
+  /// Unlimited-length text
+  /// SQL: TEXT
+  /// Use this for large text content like descriptions, bodies, comments
+  Text
 
   /// Fixed-length string
   /// SQL: CHAR, CHARACTER
@@ -205,9 +210,15 @@ pub fn decimal(name: String, precision: Int, scale: Int) -> Field {
   new(name, Decimal(precision, scale))
 }
 
-/// Create a string/text field
+/// Create a string/varchar field
 pub fn string(name: String) -> Field {
   new(name, String)
+}
+
+/// Create a text field (unlimited length)
+/// Use this for large text content like descriptions, article bodies, comments
+pub fn text(name: String) -> Field {
+  new(name, Text)
 }
 
 /// Create a boolean field
@@ -468,6 +479,7 @@ pub fn type_name(field_type: FieldType) -> String {
     Decimal(p, s) ->
       "decimal(" <> int.to_string(p) <> "," <> int.to_string(s) <> ")"
     String -> "string"
+    Text -> "text"
     Char(l) -> "char(" <> int.to_string(l) <> ")"
     Boolean -> "boolean"
     DateTime -> "datetime"
@@ -495,7 +507,7 @@ pub fn is_numeric_type(field_type: FieldType) -> Bool {
 /// Check if a field type is text-like
 pub fn is_text_type(field_type: FieldType) -> Bool {
   case field_type {
-    String | Char(_) -> True
+    String | Text | Char(_) -> True
     Nullable(inner) -> is_text_type(inner)
     _ -> False
   }

--- a/test/cquill/schema/field_test.gleam
+++ b/test/cquill/schema/field_test.gleam
@@ -2,7 +2,7 @@ import cquill/schema/field.{
   Array, BigInteger, Boolean, Cascade, Char, Check, Custom, Date, DateTime,
   Decimal, DefaultAutoIncrement, DefaultFunction, DefaultValue, Enum, Float,
   ForeignKey, Integer, Json, MaxLength, MaxValue, MinLength, MinValue, NoAction,
-  Nullable, Pattern, Restrict, SetNull, String, Time, Uuid,
+  Nullable, Pattern, Restrict, SetNull, String, Text, Time, Uuid,
 }
 import gleam/dynamic
 import gleam/option.{None, Some}
@@ -31,6 +31,13 @@ pub fn string_field_test() {
 
   field.get_name(f) |> should.equal("email")
   field.get_type(f) |> should.equal(String)
+}
+
+pub fn text_field_test() {
+  let f = field.text("description")
+
+  field.get_name(f) |> should.equal("description")
+  field.get_type(f) |> should.equal(Text)
 }
 
 pub fn big_integer_field_test() {
@@ -295,7 +302,9 @@ pub fn comment_test() {
 pub fn type_name_test() {
   field.type_name(Integer) |> should.equal("integer")
   field.type_name(String) |> should.equal("string")
+  field.type_name(Text) |> should.equal("text")
   field.type_name(Nullable(String)) |> should.equal("string?")
+  field.type_name(Nullable(Text)) |> should.equal("text?")
   field.type_name(Array(Integer)) |> should.equal("array(integer)")
   field.type_name(Decimal(10, 2)) |> should.equal("decimal(10,2)")
   field.type_name(Enum("status", [])) |> should.equal("enum:status")
@@ -313,8 +322,10 @@ pub fn is_numeric_type_test() {
 
 pub fn is_text_type_test() {
   field.is_text_type(String) |> should.be_true
+  field.is_text_type(Text) |> should.be_true
   field.is_text_type(Char(10)) |> should.be_true
   field.is_text_type(Nullable(String)) |> should.be_true
+  field.is_text_type(Nullable(Text)) |> should.be_true
   field.is_text_type(Integer) |> should.be_false
 }
 


### PR DESCRIPTION
## Summary
- Adds `Text` variant to `FieldType` for unlimited-length text content
- Adds `field.text()` constructor function
- Distinguishes TEXT (unlimited) from String/VARCHAR (length-limited)

Closes #124

## Working Example

```gleam
import cquill/schema
import cquill/schema/field

// Create a schema with text fields for large content
let post_schema =
  schema.new("posts")
  |> schema.add_field(field.integer("id") |> field.primary_key)
  |> schema.add_field(field.string("title") |> field.not_null)  // VARCHAR for short text
  |> schema.add_field(field.text("body") |> field.not_null)     // TEXT for article body
  |> schema.add_field(field.text("summary") |> field.nullable)  // TEXT for description

// field.text() creates a Text type
let description = field.text("description")
field.get_type(description)  // => Text
field.type_name(field.Text)  // => "text"

// Text is recognized as text-like
field.is_text_type(field.Text)           // => True
field.is_text_type(field.Nullable(field.Text))  // => True
```

## Test plan
- [x] Added `text_field_test` - verifies field.text() creates Text type
- [x] Added Text to `type_name_test` - verifies "text" and "text?" output
- [x] Added Text to `is_text_type_test` - verifies Text and Nullable(Text) are text types
- [x] All 1382 tests pass
- [x] Code formatted with `gleam format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)