### PR TITLE
feat: add has_errors() and error_count() convenience functions to changeset

### DIFF
--- a/src/cquill/changeset.gleam
+++ b/src/cquill/changeset.gleam
@@ -491,6 +491,21 @@ pub fn has_error(changeset: Changeset, field: String) -> Bool {
   }
 }
 
+/// Check if the changeset has any validation errors
+/// This is a convenience function to check if any field has errors
+pub fn has_errors(changeset: Changeset) -> Bool {
+  !dict.is_empty(changeset.errors)
+}
+
+/// Count the total number of validation errors across all fields
+/// Returns the sum of all errors on all fields
+pub fn error_count(changeset: Changeset) -> Int {
+  changeset.errors
+  |> dict.values
+  |> list.map(list.length)
+  |> int.sum
+}
+
 // ============================================================================
 // RESULT FUNCTIONS
 // ============================================================================


### PR DESCRIPTION
## Summary
- Adds `has_errors(changeset)` - check if changeset has ANY validation errors
- Adds `error_count(changeset)` - get total count of errors across all fields
- Complements existing `has_error(changeset, field)` for field-specific checks

Closes #125

## Working Example

```gleam
import cquill/changeset
import gleam/dict
import gleam/dynamic

// Create a changeset with validation errors
let data =
  dict.new()
  |> dict.insert("email", dynamic.string("invalid"))
  |> dict.insert("name", dynamic.string("X"))

let cs =
  changeset.new(data)
  |> changeset.validate_format("email", "^[^@]+@[^@]+$")
  |> changeset.validate_length("name", min: 2, max: 100)

// Check if there are ANY errors (simple boolean)
changeset.has_errors(cs)  // => True

// Get total error count across all fields
changeset.error_count(cs)  // => 2

// For comparison, existing field-specific check:
changeset.has_error(cs, "email")  // => True

// Valid changeset has no errors
let valid_cs =
  changeset.new(dict.new() |> dict.insert("email", dynamic.string("test@example.com")))
  |> changeset.validate_required(["email"])

changeset.has_errors(valid_cs)   // => False
changeset.error_count(valid_cs)  // => 0
```

## Test plan
- [x] `has_errors_returns_false_for_valid_changeset_test`
- [x] `has_errors_returns_true_when_errors_exist_test`
- [x] `has_errors_returns_true_for_multiple_errors_test`
- [x] `error_count_returns_zero_for_valid_changeset_test`
- [x] `error_count_returns_one_for_single_error_test`
- [x] `error_count_returns_correct_count_for_multiple_errors_test`
- [x] `error_count_counts_all_errors_on_same_field_test`
- [x] `has_errors_and_error_count_consistency_test`
- [x] All 1390 tests pass
- [x] Code formatted with `gleam format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)